### PR TITLE
Always print a newline before exiting

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -104,10 +104,12 @@ class Outputter(object):
     else:
       self.__out_file.write("\r" + msg[:self.__width].ljust(self.__width))
       self.__previous_line_was_transient = True
-  def permanent_line(self, msg):
+  def flush_transient_output(self):
     if self.__previous_line_was_transient:
       self.__out_file.write("\n")
       self.__previous_line_was_transient = False
+  def permanent_line(self, msg):
+    self.flush_transient_output()
     self.__out_file.write(msg + "\n")
 
 stdout_lock = threading.Lock()
@@ -169,6 +171,7 @@ class FilterFormat:
                               % (len(self.failures), self.total_tests))
       for (binary, test) in self.failures:
         self.out.permanent_line(" " + binary + ": " + test)
+    self.out.flush_transient_output()
 
 class RawFormat:
   def log(self, line):


### PR DESCRIPTION
We used to not print a newline at the end if the last line was a
transient. It looked OK anyway, because transient lines are suffixed
with just enough spaces to fill the line, but it messed with at least
one user's colored bash prompt. And ending with a newline is the right
thing to do anyway.
