### PR TITLE
Save test logs to files named after the test name.

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -394,7 +394,9 @@ if options.failed:
 tests.sort(reverse=True, key=lambda x: ((1 if x[0] is None else 0), x))
 
 # Repeat tests (-r flag).
+indices = [str(i/len(tests) + 1) for i in range(options.repeat * len(tests))]
 tests *= options.repeat
+tests = zip(tests, indices)
 test_lock = threading.Lock()
 job_id = 0
 logger.log(str(-1) + ': TESTCNT ' + ' ' + str(len(tests)))
@@ -415,16 +417,14 @@ for logfile in os.listdir(options.output_dir):
 # Run the specified job. Return the elapsed time in milliseconds if
 # the job succeeds, or None if the job fails. (This ensures that
 # failing tests will run first the next time.)
-def run_job((command, job_id, test)):
+def run_job((command, job_id, test, test_index)):
   begin = time.time()
 
-  test_name = re.sub(r'\W', '_', test) + '__'
-  with tempfile.NamedTemporaryFile(dir=options.output_dir, delete=False,
-                                   prefix=test_name) as log:
+  test_name = re.sub(r'\W', '_', test) + '-' + test_index + '.log'
+  with open(os.path.join(options.output_dir, test_name), 'w') as log:
     sub = subprocess.Popen(command + ['--gtest_filter=' + test] +
                              ['--gtest_color=' + options.gtest_color],
-                           stdout=log.file,
-                           stderr=log.file)
+                           stdout=log, stderr=log)
     try:
       code = sigint_handler.wait(sub)
     except sigint_handler.ProcessWasInterrupted:
@@ -450,9 +450,9 @@ def worker():
     job = None
     test_lock.acquire()
     if job_id < len(tests):
-      (_, test_binary, test, command) = tests[job_id]
+      (_, test_binary, test, command), test_index = tests[job_id]
       logger.log(str(job_id) + ': TEST ' + test_binary + ' ' + test)
-      job = (command, job_id, test)
+      job = (command, job_id, test, test_index)
     job_id += 1
     test_lock.release()
     if job is None:

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -15,6 +15,7 @@
 import cPickle
 import errno
 import gzip
+import itertools
 import json
 import multiprocessing
 import optparse
@@ -394,9 +395,7 @@ if options.failed:
 tests.sort(reverse=True, key=lambda x: ((1 if x[0] is None else 0), x))
 
 # Repeat tests (-r flag).
-indices = [str(i/len(tests) + 1) for i in range(options.repeat * len(tests))]
-tests *= options.repeat
-tests = zip(tests, indices)
+tests = list(itertools.product(tests, range(1, options.repeat + 1)))
 test_lock = threading.Lock()
 job_id = 0
 logger.log(str(-1) + ': TESTCNT ' + ' ' + str(len(tests)))
@@ -420,7 +419,7 @@ for logfile in os.listdir(options.output_dir):
 def run_job((command, job_id, test, test_index)):
   begin = time.time()
 
-  test_name = re.sub(r'\W', '_', test) + '-' + test_index + '.log'
+  test_name = re.sub(r'\W', '_', test) + '-' + str(test_index) + '.log'
   with open(os.path.join(options.output_dir, test_name), 'w') as log:
     sub = subprocess.Popen(command + ['--gtest_filter=' + test] +
                              ['--gtest_color=' + options.gtest_color],

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -395,7 +395,7 @@ if options.failed:
 tests.sort(reverse=True, key=lambda x: ((1 if x[0] is None else 0), x))
 
 # Repeat tests (-r flag).
-tests = list(itertools.product(tests, range(1, options.repeat + 1)))
+tests = [(test, i + 1) for test in tests for i in range(options.repeat)]
 test_lock = threading.Lock()
 job_id = 0
 logger.log(str(-1) + ': TESTCNT ' + ' ' + str(len(tests)))
@@ -419,7 +419,7 @@ for logfile in os.listdir(options.output_dir):
 def run_job((command, job_id, test, test_index)):
   begin = time.time()
 
-  test_name = re.sub(r'\W', '_', test) + '-' + str(test_index) + '.log'
+  test_name = re.sub('[^A-Za-z0-9]', '_', test) + '-' + str(test_index) + '.log'
   with open(os.path.join(options.output_dir, test_name), 'w') as log:
     sub = subprocess.Popen(command + ['--gtest_filter=' + test] +
                              ['--gtest_color=' + options.gtest_color],
@@ -449,7 +449,7 @@ def worker():
     job = None
     test_lock.acquire()
     if job_id < len(tests):
-      (_, test_binary, test, command), test_index = tests[job_id]
+      ((_, test_binary, test, command), test_index) = tests[job_id]
       logger.log(str(job_id) + ': TEST ' + test_binary + ' ' + test)
       job = (command, job_id, test, test_index)
     job_id += 1

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -418,17 +418,19 @@ for logfile in os.listdir(options.output_dir):
 def run_job((command, job_id, test)):
   begin = time.time()
 
-  log_filename = os.path.join(options.output_dir, re.sub(r'\W', '_', test))
-  with open(log_filename, 'w') as log:
+  test_name = re.sub(r'\W', '_', test) + '__'
+  with tempfile.NamedTemporaryFile(dir=options.output_dir, delete=False,
+                                   prefix=test_name) as log:
     sub = subprocess.Popen(command + ['--gtest_filter=' + test] +
-                           ['--gtest_color=' + options.gtest_color],
-                           stdout=log, stderr=log)
+                             ['--gtest_color=' + options.gtest_color],
+                           stdout=log.file,
+                           stderr=log.file)
     try:
       code = sigint_handler.wait(sub)
     except sigint_handler.ProcessWasInterrupted:
       thread.exit()
     runtime_ms = int(1000 * (time.time() - begin))
-    logger.logfile(job_id, log_filename)
+    logger.logfile(job_id, log.name)
 
   test_results.log(test, {
       "expected": "PASS",

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -19,6 +19,7 @@ import json
 import multiprocessing
 import optparse
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -417,17 +418,17 @@ for logfile in os.listdir(options.output_dir):
 def run_job((command, job_id, test)):
   begin = time.time()
 
-  with tempfile.NamedTemporaryFile(dir=options.output_dir, delete=False) as log:
+  log_filename = os.path.join(options.output_dir, re.sub(r'\W', '_', test))
+  with open(log_filename, 'w') as log:
     sub = subprocess.Popen(command + ['--gtest_filter=' + test] +
-                             ['--gtest_color=' + options.gtest_color],
-                           stdout=log.file,
-                           stderr=log.file)
+                           ['--gtest_color=' + options.gtest_color],
+                           stdout=log, stderr=log)
     try:
       code = sigint_handler.wait(sub)
     except sigint_handler.ProcessWasInterrupted:
       thread.exit()
     runtime_ms = int(1000 * (time.time() - begin))
-    logger.logfile(job_id, log.name)
+    logger.logfile(job_id, log_filename)
 
   test_results.log(test, {
       "expected": "PASS",

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -15,7 +15,6 @@
 import cPickle
 import errno
 import gzip
-import itertools
 import json
 import multiprocessing
 import optparse


### PR DESCRIPTION
This will make it easier to find and examine the logs of a given test even if it doesn't fail.