### PR TITLE
Refactor gtest-parallel.

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -30,6 +30,10 @@ import threading
 import time
 import zlib
 
+
+INF = float("inf")
+
+
 # An object that catches SIGINT sent to the Python process and notices
 # if processes passed to wait() die by SIGINT (we need to look for
 # both of those cases, because pressing Ctrl+C can result in either
@@ -83,7 +87,7 @@ def term_width(out):
   if not out.isatty():
     return None
   try:
-    p = subprocess.Popen(["stty", "size"],
+    p = subprocess.Popen(['stty', 'size'],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = p.communicate()
     if p.returncode != 0 or err:
@@ -103,142 +107,237 @@ class Outputter(object):
     self.__width = term_width(out_file)  # Line width, or None if not a tty.
   def transient_line(self, msg):
     if self.__width is None:
-      self.__out_file.write(msg + "\n")
+      self.__out_file.write(msg + '\n')
     else:
-      self.__out_file.write("\r" + msg[:self.__width].ljust(self.__width))
+      self.__out_file.write('\r' + msg[:self.__width].ljust(self.__width))
       self.__previous_line_was_transient = True
   def flush_transient_output(self):
     if self.__previous_line_was_transient:
-      self.__out_file.write("\n")
+      self.__out_file.write('\n')
       self.__previous_line_was_transient = False
   def permanent_line(self, msg):
     self.flush_transient_output()
-    self.__out_file.write(msg + "\n")
+    self.__out_file.write(msg + '\n')
 
-stdout_lock = threading.Lock()
+
+class Test(object):
+  def __init__(self, test_id, name, binary, command):
+    self.name = name
+    self.binary = binary
+    self.command = command
+    self.test_id = test_id
+
+
+class Task(object):
+  def __init__(self, task_id, test, execution_number, last_execution_time,
+               logger, output_dir, task_started_callback,
+               task_finished_callback):
+    self.test = test
+    self.logger = logger
+    self.task_id = task_id
+    self.execution_number = execution_number
+    self.last_execution_time = last_execution_time
+    self.task_started_callback = task_started_callback
+    self.task_finished_callback = task_finished_callback
+
+    self.command = self.test.command + ['--gtest_filter=' + self.test.name]
+    log_name = '%s-%s-%s.log' % (self.__normalize(self.test.binary),
+                                 self.__normalize(self.test.name),
+                                 self.execution_number)
+
+    self.log_file = os.path.join(output_dir, log_name)
+
+    self.exit_code = None
+    self.runtime_ms = None
+
+  def __normalize(self, string):
+    return re.sub('[^A-Za-z0-9]', '_', string)
+
+  def run(self):
+    self.task_started_callback(self.task_id)
+    self.logger.log(self.task_id, 'START')
+    begin = time.time()
+    with open(self.log_file, 'w') as log:
+      task = subprocess.Popen(self.command, stdout=log, stderr=log)
+      try:
+        self.exit_code = sigint_handler.wait(task)
+      except sigint_handler.ProcessWasInterrupted:
+        thread.exit()
+      self.runtime_ms = int(1000 * (time.time() - begin))
+    self.logger.log(self.task_id, 'EXIT', (self.test.name, self.exit_code,
+                                           self.runtime_ms),
+                    self.log_file)
+    self.task_finished_callback(self.task_id)
+
+
+class ExecutionManager(object):
+  def __init__(self, times_db, logger, output_dir, max_retries):
+    self.logger = logger
+    self.times_db = times_db
+    self.output_dir = output_dir
+    self.max_retries = max_retries
+
+    self.tasks = []
+    self.tests = []
+    self.failed = []
+    self.passed = []
+    self.queued = []
+    self.exit_code = 0
+    self.started = set()
+    self.tasks_by_test = {}
+
+  def register_test(self, test_name, test_binary, test_command,
+                    times_to_repeat):
+    test_id = len(self.tests)
+    self.tests.append(Test(test_id, test_name, test_binary, test_command))
+    last_execution_time = self.times_db.get_test_time(test_binary, test_name)
+    for execution_number in range(1, times_to_repeat + 1):
+      self.register_task(test_id, execution_number, last_execution_time)
+
+  def register_task(self, test_id, execution_number, last_execution_time):
+    task_id = len(self.tasks)
+    self.queued.append(task_id)
+    self.tasks_by_test.setdefault(test_id, []).append(task_id)
+    self.tasks.append(Task(task_id, self.tests[test_id], execution_number,
+                           last_execution_time, self.logger, self.output_dir,
+                           self.__task_started_callback,
+                           self.__task_finished_callback))
+
+  def get_tasks(self):
+    tasks = [self.tasks[task_id] for task_id in self.queued]
+    self.queued = []
+    return sorted(tasks, key=lambda task: task.last_execution_time,
+                  reverse=True)
+
+  def __task_started_callback(self, task_id):
+    self.started.add(task_id)
+
+  def __task_finished_callback(self, task_id):
+    self.started.remove(task_id)
+    task = self.tasks[task_id]
+    test_id = task.test.test_id
+    self.times_db.record_test_time(task.test.binary, task.test.name,
+                                   task.runtime_ms, task.exit_code)
+    if task.exit_code == 0:
+      self.passed.append(task_id)
+    else:
+      self.failed.append(task_id)
+      self.exit_code = task.exit_code
+      if len(self.tasks_by_test[test_id]) <= self.max_retries:
+        self.register_task(test_id, len(self.tasks_by_test[test_id]) + 1,
+                           task.runtime_ms)
+
+  def get_failed_tasks(self):
+    return [self.tasks[task_id] for task_id in self.failed]
+
+  def get_passed_tasks(self):
+    return [self.tasks[task_id] for task_id in self.passed]
+
+  def get_started_tasks(self):
+    return [self.tasks[task_id] for task_id in self.started]
+
+
+class WorkerPool(object):
+  def __init__(self, workers, tasks, timeout):
+    self.tasks = tasks
+    self.workers = workers
+    self.timeout = timeout
+
+    self.task_id = 0
+    self.task_lock = threading.Lock()
+
+  def __worker_function(self):
+    while True:
+      task = None
+      with self.task_lock:
+        if self.task_id < len(self.tasks):
+          task = self.tasks[self.task_id]
+        self.task_id += 1
+      if task is None:
+        return
+      task.run()
+
+  def __start_daemon(self):
+    worker = threading.Thread(target=self.__worker_function)
+    worker.daemon = True
+    worker.start()
+    return worker
+
+  def run_tasks(self):
+    try:
+      self.timeout.start()
+      workers = [self.__start_daemon() for _ in range(self.workers)]
+      for worker in workers:
+        worker.join()
+    finally:
+      self.timeout.cancel()
+
 
 class FilterFormat:
-  if sys.stdout.isatty():
-    # stdout needs to be unbuffered since the output is interactive.
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+  def __init__(self):
+    if sys.stdout.isatty():
+      # stdout needs to be unbuffered since the output is interactive.
+      sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+    self.stdout_lock = threading.Lock()
+    self.out = Outputter(sys.stdout)
+    self.total_tasks = 0
+    self.finished_tasks = 0
 
-  out = Outputter(sys.stdout)
-  total_tests = 0
-  finished_tests = 0
+  def print_tasks(self, message, tasks):
+    self.out.permanent_line('%s (%s/%s):' %
+                            (message, len(tasks), self.total_tasks))
+    for task in tasks:
+      self.out.permanent_line(' %s: %s run #%d' % (task.test.binary,
+                                                   task.test.name,
+                                                   task.execution_number))
 
-  tests = {}
-  outputs = {}
-  passed = []
-  failed = []
-  started = set()
+  def print_test_status(self, last_finished_task, time_ms):
+    self.out.transient_line('[%d/%d] %s (%d ms)'
+                            % (self.finished_tasks, self.total_tasks,
+                               last_finished_task, time_ms))
 
-  def move_to(self, destination_dir, test_ids):
-    destination_dir = os.path.join(self.output_dir, destination_dir)
-    os.makedirs(destination_dir)
-    for test_id in test_ids:
-        log_file = self.outputs[test_id]
-        test_name = os.path.basename(log_file)
-        shutil.move(log_file, os.path.join(destination_dir, test_name))
-
-  def print_tests(self, message, test_ids):
-    self.out.permanent_line("%s (%s/%s):" %
-                            (message, len(test_ids), self.total_tests))
-    test_ids = sorted(test_ids, key=lambda test_id: self.tests[test_id])
-    for test_id in test_ids:
-      self.out.permanent_line(" %s: %s" % self.tests[test_id])
-
-  def print_test_status(self, last_finished_test, time_ms):
-    self.out.transient_line("[%d/%d] %s (%d ms)"
-                            % (self.finished_tests, self.total_tests,
-                               last_finished_test, time_ms))
-
-  def log(self, job_id, command, args=tuple(), file_name=None):
-    with stdout_lock:
-      if command == "TEST":
-        self.tests[job_id] = args
-      elif command == "START":
-        self.started.add(job_id)
-        self.outputs[job_id] = file_name
-      elif command == "EXIT":
-        self.started.remove(job_id)
-        self.finished_tests += 1
-        (exit_code, time_ms) = args
-        (binary, test) = self.tests[job_id]
+  def log(self, task_id, command, args=tuple(), file_name=None):
+    with self.stdout_lock:
+      if command == 'EXIT':
+        self.finished_tasks += 1
+        (test, exit_code, time_ms) = args
         self.print_test_status(test, time_ms)
-        if exit_code == 0:
-          self.passed.append(job_id)
-        else:
-          self.failed.append(job_id)
+        if exit_code:
           with open(file_name) as f:
             for line in f.readlines():
               self.out.permanent_line(line.rstrip())
           self.out.permanent_line(
-            "[%d/%d] %s returned/aborted with exit code %d (%d ms)"
-            % (self.finished_tests, self.total_tests, test, exit_code, time_ms))
-      elif command == "TESTCNT":
-        self.total_tests = args[0]
-        self.out.transient_line("[0/%d] Running tests..." % self.total_tests)
+            '[%d/%d] %s returned/aborted with exit code %d (%d ms)'
+            % (self.finished_tasks, self.total_tasks, test, exit_code, time_ms))
+      elif command == 'TESTCNT':
+        self.total_tasks += args[0]
+        self.out.transient_line('[0/%d] Running tests...' % self.total_tasks)
 
-  def end(self):
-    if self.passed:
-      self.move_to('passed', self.passed)
-    if self.failed:
-      self.print_tests("FAILED TESTS", self.failed)
-      self.move_to('failed', self.failed)
-    if self.started:
-      self.print_tests("INTERRUPTED TESTS", self.started)
-      self.move_to('interrupted', self.started)
+  def log_failed_and_interrupted_tasks(self, failed, interrupted):
+    if failed:
+      self.print_tasks('FAILED TESTS', failed)
+    if interrupted:
+      self.print_tasks('INTERRUPTED TESTS', interrupted)
     self.out.flush_transient_output()
 
+
 class RawFormat:
-  def log(self, job_id, command, args=tuple(), file_name=None):
-    stdout_lock.acquire()
-    line = "%d: %s %s" % (job_id, command, ' '.join(str(arg) for arg in args))
-    sys.stdout.write(line + "\n")
-    if command == "EXIT":
-      with open(file_name) as f:
-        for line in f:
-          sys.stdout.write("%d > %s" % (job_id, line))
-    sys.stdout.flush()
-    stdout_lock.release()
-  def end(self):
+  def __init__(self):
+    self.stdout_lock = threading.Lock()
+
+  def log(self, task_id, command, args=tuple(), file_name=None):
+    with self.stdout_lock:
+      line = '%d: %s %s' % (task_id, command,
+                            ' '.join(str(arg) for arg in args))
+      sys.stdout.write(line + '\n')
+      if command == 'EXIT':
+        with open(file_name) as f:
+          for line in f:
+            sys.stdout.write('%d > %s' % (task_id, line))
+      sys.stdout.flush()
+  def log_failed_and_interrupted_tasks(self, failed, interrupted):
     pass
 
-class CollectTestResults(object):
-  def __init__(self, json_dump_filepath):
-    self.test_results_lock = threading.Lock()
-    self.json_dump_file = open(json_dump_filepath, 'w')
-    self.test_results = {
-        "interrupted": False,
-        "path_delimiter": ".",
-        # Third version of the file format. See the link in the flag description
-        # for details.
-        "version": 3,
-        "seconds_since_epoch": int(time.time()),
-        "num_failures_by_type": {
-            "PASS": 0,
-            "FAIL": 0,
-        },
-        "tests": {},
-    }
-
-  def log(self, test, result):
-    with self.test_results_lock:
-      self.test_results['num_failures_by_type'][result['actual']] += 1
-      results = self.test_results['tests']
-      for name in test.split('.'):
-        results = results.setdefault(name, {})
-      results.update(result)
-
-  def dump_to_file_and_close(self):
-    json.dump(self.test_results, self.json_dump_file)
-    self.json_dump_file.close()
-
-class IgnoreTestResults(object):
-  def log(self, test, result):
-    pass
-  def dump_to_file_and_close(self):
-    pass
 
 class DummyTimer(object):
   def start(self):
@@ -246,18 +345,19 @@ class DummyTimer(object):
   def cancel(self):
     pass
 
+
 # Record of test runtimes. Has built-in locking.
 class TestTimes(object):
   def __init__(self, save_file):
-    "Create new object seeded with saved test times from the given file."
-    self.__times = {}  # (test binary, test name) -> runtime in ms
+    'Create new object seeded with saved test times from the given file.'
+    self.__times = {}  # (test binary, test name) -> (runtime in ms, exit_code)
 
     # Protects calls to record_test_time(); other calls are not
     # expected to be made concurrently.
     self.__lock = threading.Lock()
 
     try:
-      with gzip.GzipFile(save_file, "rb") as f:
+      with gzip.GzipFile(save_file, 'rb') as f:
         times = cPickle.load(f)
     except (EOFError, IOError, cPickle.UnpicklingError, zlib.error):
       # File doesn't exist, isn't readable, is malformed---whatever.
@@ -267,9 +367,16 @@ class TestTimes(object):
     # Discard saved times if the format isn't right.
     if type(times) is not dict:
       return
-    for ((test_binary, test_name), runtime) in times.items():
+    for key, value in times.items():
+      if type(key) is not tuple or len(key) != 2:
+        return
+      if type(value) is not tuple or len(value) != 2:
+        return
+      (test_binary, test_name) = key
+      (runtime, exit_code) = value
       if (type(test_binary) is not str or type(test_name) is not str
-          or type(runtime) not in {int, long, type(None)}):
+          or type(runtime) not in {int, long, float}
+          or type(exit_code) not in {int, long}):
         return
 
     self.__times = times
@@ -277,246 +384,278 @@ class TestTimes(object):
   def get_test_time(self, binary, testname):
     """Return the last duration for the given test as an integer number of
     milliseconds, or None if the test failed or if there's no record for it."""
-    return self.__times.get((binary, testname), None)
+    if ((binary, testname) not in self.__times
+        or self.__times[binary, testname][1] != 0):
+      return INF
+    return self.__times[binary, testname]
 
-  def record_test_time(self, binary, testname, runtime_ms):
+  def record_test_time(self, binary, testname, runtime_ms, exit_code):
     """Record that the given test ran in the specified number of
-    milliseconds. If the test failed, runtime_ms should be None."""
+    milliseconds."""
     with self.__lock:
-      self.__times[(binary, testname)] = runtime_ms
+      self.__times[(binary, testname)] = (runtime_ms, exit_code)
 
   def write_to_file(self, save_file):
-    "Write all the times to file."
+    """Write all the times to file."""
     try:
-      with open(save_file, "wb") as f:
-        with gzip.GzipFile("", "wb", 9, f) as gzf:
+      with open(save_file, 'wb') as f:
+        with gzip.GzipFile('', 'wb', 9, f) as gzf:
           cPickle.dump(self.__times, gzf, cPickle.HIGHEST_PROTOCOL)
     except IOError:
       pass  # ignore errors---saving the times isn't that important
 
-# Remove additional arguments (anything after --).
-additional_args = []
 
-for i in range(len(sys.argv)):
-  if sys.argv[i] == '--':
-    additional_args = sys.argv[i+1:]
-    sys.argv = sys.argv[:i]
-    break
+def find_tests(binaries, gtest_filter, gtest_color,
+               shard_index, shard_count, additional_args, times_to_repeat,
+               run_disabled_tests, only_failed_and_new, times_db,
+               execution_manager):
+  test_count = 0
+  for test_binary in binaries:
+    test_command = [test_binary]
+    if run_disabled_tests:
+      test_command += ['--gtest_also_run_disabled_tests']
 
-parser = optparse.OptionParser(
-    usage = 'usage: %prog [options] binary [binary ...] -- [additional args]')
+    list_tests_command = test_command + ['--gtest_list_tests']
+    if gtest_filter != '':
+      list_tests_command += ['--gtest_filter=' + gtest_filter]
 
-parser.add_option('-d', '--output_dir', type='string',
-                  default=os.path.join(tempfile.gettempdir(), "gtest-parallel"),
-                  help='output directory for test logs')
-parser.add_option('-r', '--repeat', type='int', default=1,
-                  help='repeat tests')
-parser.add_option('--failed', action='store_true', default=False,
-                  help='run only failed and new tests')
-parser.add_option('-w', '--workers', type='int',
-                  default=multiprocessing.cpu_count(),
-                  help='number of workers to spawn')
-parser.add_option('--gtest_color', type='string', default='yes',
-                  help='color output')
-parser.add_option('--gtest_filter', type='string', default='',
-                  help='test filter')
-parser.add_option('--gtest_also_run_disabled_tests', action='store_true',
-                  default=False, help='run disabled tests too')
-parser.add_option('--format', type='string', default='filter',
-                  help='output format (raw,filter)')
-parser.add_option('--print_test_times', action='store_true', default=False,
-                  help='list the run time of each test at the end of execution')
-parser.add_option('--shard_count', type='int', default=1,
-                  help='total number of shards (for sharding test execution '
-                       'between multiple machines)')
-parser.add_option('--shard_index', type='int', default=0,
-                  help='zero-indexed number identifying this shard (for '
-                       'sharding test execution between multiple machines)')
-parser.add_option('--dump_json_test_results', type='string', default=None,
-                  help='Saves the results of the tests as a JSON machine-'
-                       'readable file. The format of the file is specified at '
-                       'https://www.chromium.org/developers/the-json-test-results-format')
-parser.add_option('--timeout', type='int', default=None,
-                  help='Interrupt all remaining processes after the given '
-                       'time (in seconds).')
-
-(options, binaries) = parser.parse_args()
-
-if binaries == []:
-  parser.print_usage()
-  sys.exit(1)
-
-logger = RawFormat()
-if options.format == 'raw':
-  pass
-elif options.format == 'filter':
-  logger = FilterFormat()
-  logger.output_dir = options.output_dir
-else:
-  parser.error("Unknown output format: " + options.format)
-
-if options.shard_count < 1:
-  parser.error("Invalid number of shards: %d. Must be at least 1." %
-               options.shard_count)
-if not (0 <= options.shard_index < options.shard_count):
-  parser.error("Invalid shard index: %d. Must be between 0 and %d "
-               "(less than the number of shards)." %
-               (options.shard_index, options.shard_count - 1))
-
-timeout = (DummyTimer() if options.timeout is None
-           else threading.Timer(options.timeout, sigint_handler.interrupt))
-
-test_results = (IgnoreTestResults() if options.dump_json_test_results is None
-                else CollectTestResults(options.dump_json_test_results))
-
-# Check that all test binaries have an unique basename. That way we can ensure
-# the logs are saved to unique files even when two different binaries have
-# common tests.
-unique_binaries = set(os.path.basename(binary) for binary in binaries)
-assert len(unique_binaries) == len(binaries), (
-    "All test binaries must have an unique basename.")
-
-# Find tests.
-save_file = os.path.join(os.path.expanduser("~"), ".gtest-parallel-times")
-times = TestTimes(save_file)
-tests = []
-for test_binary in binaries:
-  command = [test_binary]
-  if options.gtest_also_run_disabled_tests:
-    command += ['--gtest_also_run_disabled_tests']
-
-  list_command = list(command)
-  if options.gtest_filter != '':
-    list_command += ['--gtest_filter=' + options.gtest_filter]
-
-  try:
-    test_list = subprocess.Popen(list_command + ['--gtest_list_tests'],
-                                 stdout=subprocess.PIPE).communicate()[0]
-  except OSError as e:
-    sys.exit("%s: %s" % (test_binary, str(e)))
-
-  command += additional_args
-
-  test_group = ''
-  for line in test_list.split('\n'):
-    if not line.strip():
-      continue
-    if line[0] != " ":
-      # Remove comments for typed tests and strip whitespace.
-      test_group = line.split('#')[0].strip()
-      continue
-    # Remove comments for parameterized tests and strip whitespace.
-    line = line.split('#')[0].strip()
-    if not line:
-      continue
-
-    test = test_group + line
-    if not options.gtest_also_run_disabled_tests and 'DISABLED_' in test:
-      continue
-    tests.append((times.get_test_time(test_binary, test),
-                  test_binary, test, command))
-
-tests = tests[options.shard_index::options.shard_count]
-
-if options.failed:
-  # The first element of each entry is the runtime of the most recent
-  # run if it was successful, or None if the test is new or the most
-  # recent run failed.
-  tests = [x for x in tests if x[0] is None]
-
-# Sort tests by falling runtime (with None, which is what we get for
-# new and failing tests, being considered larger than any real
-# runtime).
-tests.sort(reverse=True, key=lambda x: ((1 if x[0] is None else 0), x))
-
-# Repeat tests (-r flag).
-tests = [(test, i + 1) for test in tests for i in range(options.repeat)]
-test_lock = threading.Lock()
-job_id = 0
-logger.log(-1, "TESTCNT", (len(tests),))
-
-exit_code = 0
-
-# Remove files from old test runs.
-if os.path.isdir(options.output_dir):
-  shutil.rmtree(options.output_dir)
-# Create directory for test log output.
-try:
-  os.makedirs(options.output_dir)
-except OSError as e:
-  # Ignore errors if this directory already exists.
-  if e.errno != errno.EEXIST or not os.path.isdir(options.output_dir):
-    raise e
-
-# Run the specified job. Return the elapsed time in milliseconds if
-# the job succeeds, or None if the job fails. (This ensures that
-# failing tests will run first the next time.)
-def run_job((command, job_id, test, test_index)):
-  begin = time.time()
-
-  test_binary = re.sub('[^A-Za-z0-9]', '_', os.path.basename(command[-1]))
-  test_name = re.sub('[^A-Za-z0-9]', '_', test)
-  test_file = os.path.join(options.output_dir, '%s-%s-%s.log' % (
-      test_binary, test_name, test_index))
-  logger.log(job_id, "START", file_name=test_file)
-  with open(test_file, 'w') as log:
-    sub = subprocess.Popen(command + ['--gtest_filter=' + test] +
-                             ['--gtest_color=' + options.gtest_color],
-                           stdout=log, stderr=log)
     try:
-      code = sigint_handler.wait(sub)
-    except sigint_handler.ProcessWasInterrupted:
-      thread.exit()
-    runtime_ms = int(1000 * (time.time() - begin))
+      test_list = subprocess.Popen(list_tests_command,
+                                   stdout=subprocess.PIPE).communicate()[0]
+    except OSError as e:
+      sys.exit('%s: %s' % (test_binary, str(e)))
 
-  test_results.log(test, {
-      "expected": "PASS",
-      "actual": "PASS" if code == 0 else "FAIL",
-      "time": runtime_ms,
-  })
-  logger.log(job_id, "EXIT", (code, runtime_ms), file_name=test_file)
-  if code == 0:
-    return runtime_ms
-  global exit_code
-  exit_code = code
-  return None
+    test_command += additional_args + ['--gtest_color=' + gtest_color]
 
-def worker():
-  global job_id
-  while True:
-    job = None
-    test_lock.acquire()
-    if job_id < len(tests):
-      ((_, test_binary, test, command), test_index) = tests[job_id]
-      logger.log(job_id, "TEST", (test_binary, test))
-      job = (command, job_id, test, test_index)
-    job_id += 1
-    test_lock.release()
-    if job is None:
-      return
-    times.record_test_time(test_binary, test, run_job(job))
+    test_group = ''
+    for line in test_list.split('\n'):
+      if not line.strip():
+        continue
+      if line[0] != ' ':
+        # Remove comments for typed tests and strip whitespace.
+        test_group = line.split('#')[0].strip()
+        continue
+      # Remove comments for parameterized tests and strip whitespace.
+      line = line.split('#')[0].strip()
+      if not line:
+        continue
 
-def start_daemon(func):
-  t = threading.Thread(target=func)
-  t.daemon = True
-  t.start()
-  return t
+      test_name = test_group + line
+      if not run_disabled_tests and 'DISABLED_' in test_name:
+        continue
 
-try:
-  timeout.start()
-  workers = [start_daemon(worker) for i in range(options.workers)]
-  [t.join() for t in workers]
-finally:
-  timeout.cancel()
+      test_binary = os.path.basename(test_binary)
+      last_execution_time = times_db.get_test_time(test_binary, test_name)
+      # The last execution time is INF if the test is new or the most recent
+      # run failed.
+      if only_failed_and_new and last_execution_time != INF:
+        continue
 
-logger.end()
-times.write_to_file(save_file)
-if options.print_test_times:
-  ts = sorted((times.get_test_time(test_binary, test), test_binary, test)
-              for (_, test_binary, test, _) in tests
-              if times.get_test_time(test_binary, test) is not None)
-  for (time_ms, test_binary, test) in ts:
-    print "%8s %s" % ("%dms" % time_ms, test)
+      if (test_count - shard_index) % shard_count == 0:
+        execution_manager.register_test(test_name, test_binary, test_command,
+                                        times_to_repeat)
+      test_count += 1
 
-test_results.dump_to_file_and_close()
-sys.exit(-signal.SIGINT if sigint_handler.got_sigint() else exit_code)
+
+def collect_test_results(execution_manager, json_dump_filepath):
+  test_results = {
+      'interrupted': False,
+      'path_delimiter': '.',
+      # Third version of the file format. See the link in the flag description
+      # for details.
+      'version': 3,
+      'seconds_since_epoch': int(time.time()),
+      'num_failures_by_type': {
+          'PASS': 0,
+          'FAIL': 0,
+      },
+      'tests': {},
+  }
+
+  for test_id, task_ids in execution_manager.tasks_by_test.items():
+    times = []
+    actual_results = []
+    for task_id in task_ids:
+      task = execution_manager.tasks[task_id]
+      if not task.runtime_ms:
+        continue
+      actual_result = 'PASS' if task.exit_code == 0 else 'FAIL'
+      test_results['num_failures_by_type'][actual_result] += 1
+      actual_results.append(actual_result)
+      times.append(task.runtime_ms)
+
+    if not actual_results:
+      continue
+
+    results = test_results['tests']
+    test = execution_manager.tests[test_id]
+    for name in [test.binary] + test.name.split('.'):
+      results = results.setdefault(name, {})
+
+    results['expected'] = 'PASS'
+    results['actual'] = ' '.join(actual_results)
+    results['times'] = times
+    results['time'] = times[0]
+
+  with open(json_dump_filepath, 'w') as json_dump_file:
+    json.dump(test_results, json_dump_file)
+
+
+def move_logs_to(logs, output_dir):
+  os.makedirs(output_dir)
+  for log in logs:
+    shutil.move(log, output_dir)
+
+
+def main(output_dir, times_to_repeat, only_failed_and_new, workers, gtest_color,
+         gtest_filter, run_disabled_tests, log_format, print_test_times,
+         shard_count, shard_index, json_dump_filepath, timeout, retry_failures):
+  # Remove files from old test runs.
+  if os.path.isdir(output_dir):
+    shutil.rmtree(output_dir)
+  # Create directory for test log output.
+  try:
+    os.makedirs(output_dir)
+  except OSError as e:
+    # Ignore errors if this directory already exists.
+    if e.errno != errno.EEXIST or not os.path.isdir(output_dir):
+      raise e
+
+  logger = (RawFormat() if log_format == 'raw' else FilterFormat())
+
+  timeout = (DummyTimer() if timeout is None
+             else threading.Timer(timeout, sigint_handler.interrupt))
+
+  times_db_file = os.path.join(os.path.expanduser('~'), '.gtest-parallel-times')
+  times_db = TestTimes(times_db_file)
+
+  execution_manager = ExecutionManager(times_db, logger, output_dir,
+                                       retry_failures)
+
+  find_tests(binaries, gtest_filter, gtest_color, shard_index, shard_count,
+             additional_args, times_to_repeat, run_disabled_tests,
+             only_failed_and_new, times_db, execution_manager)
+
+  tasks = execution_manager.get_tasks()
+  while tasks:
+    logger.log(-1, 'TESTCNT', (len(tasks),))
+    worker_pool = WorkerPool(workers, tasks, timeout)
+    worker_pool.run_tasks()
+
+    tasks = execution_manager.get_tasks()
+
+  failed_tasks = execution_manager.get_failed_tasks()
+  passed_tasks = execution_manager.get_passed_tasks()
+  interrupted_tasks = execution_manager.get_started_tasks()
+
+  logger.log_failed_and_interrupted_tasks(failed_tasks, interrupted_tasks)
+
+  times_db.write_to_file(times_db_file)
+  if print_test_times:
+    ts = sorted(filter(lambda task: task.runtime_ms < INF, tasks),
+                key=lambda task: task.runtime_ms)
+    for task in ts:
+      task_runtime = '%dms' % task.runtime_ms
+      print '%8s %s run #%d' % (task_runtime, task.test.name,
+                                task.execution_number)
+
+  if json_dump_filepath:
+    collect_test_results(execution_manager, json_dump_filepath)
+
+  if failed_tasks:
+    move_logs_to([task.log_file for task in failed_tasks],
+                 os.path.join(output_dir, "failed"))
+  if passed_tasks:
+    move_logs_to([task.log_file for task in passed_tasks],
+                 os.path.join(output_dir, "passed"))
+  if interrupted_tasks:
+    move_logs_to([task.log_file for task in interrupted_tasks],
+                 os.path.join(output_dir, "interrupted"))
+
+  if sigint_handler.got_sigint():
+    return -signal.SIGINT
+
+  return execution_manager.exit_code
+
+
+if __name__ == '__main__':
+  additional_args = []
+
+  for i in range(len(sys.argv)):
+    if sys.argv[i] == '--':
+      additional_args = sys.argv[i+1:]
+      sys.argv = sys.argv[:i]
+      break
+
+  parser = optparse.OptionParser(
+      usage = 'usage: %prog [options] binary [binary ...] -- [additional args]')
+
+  parser.add_option('-d', '--output_dir', type='string',
+                    default=os.path.join(tempfile.gettempdir(),
+                                         'gtest-parallel'),
+                    help='output directory for test logs')
+  parser.add_option('-r', '--repeat', type='int', default=1,
+                    help='repeat tests')
+  parser.add_option('--failed', action='store_true', default=False,
+                    help='run only failed and new tests')
+  parser.add_option('-w', '--workers', type='int',
+                    default=multiprocessing.cpu_count(),
+                    help='number of workers to spawn')
+  parser.add_option('--gtest_color', type='string', default='yes',
+                    help='color output')
+  parser.add_option('--gtest_filter', type='string', default='',
+                    help='test filter')
+  parser.add_option('--gtest_also_run_disabled_tests', action='store_true',
+                    default=False, help='run disabled tests too')
+  parser.add_option('--format', type='string', default='filter',
+                    help='output format (raw,filter)')
+  parser.add_option('--print_test_times', action='store_true', default=False,
+                    help='list the run time of each test at the end of '
+                         'execution')
+  parser.add_option('--shard_count', type='int', default=1,
+                    help='total number of shards (for sharding test execution '
+                         'between multiple machines)')
+  parser.add_option('--shard_index', type='int', default=0,
+                    help='zero-indexed number identifying this shard (for '
+                         'sharding test execution between multiple machines)')
+  parser.add_option('--dump_json_test_results', type='string', default=None,
+                    help='Saves the results of the tests as a JSON machine-'
+                         'readable file. The format of the file is specified '
+                         'at https://www.chromium.org/developers/the-json-test-results-format')
+  parser.add_option('--timeout', type='int', default=None,
+                    help='Interrupt all remaining processes after the given '
+                         'time (in seconds).')
+  parser.add_option('--retry_failures', type='int', default=0,
+                    help='Number of times to retry failing tests.')
+
+  (options, binaries) = parser.parse_args()
+
+  if binaries == []:
+    parser.print_usage()
+    sys.exit(1)
+
+  # Check that all test binaries have an unique basename. That way we can ensure
+  # the logs are saved to unique files even when two different binaries have
+  # common tests.
+  unique_binaries = set(os.path.basename(binary) for binary in binaries)
+  assert len(unique_binaries) == len(binaries), (
+      'All test binaries must have an unique basename.')
+
+
+  if options.format not in ('filter', 'raw'):
+    parser.error('Unknown output format: ' + options.format)
+
+  if options.shard_count < 1:
+    parser.error('Invalid number of shards: %d. Must be at least 1.' %
+                 options.shard_count)
+  if not (0 <= options.shard_index < options.shard_count):
+    parser.error('Invalid shard index: %d. Must be between 0 and %d '
+                 '(less than the number of shards).' %
+                 (options.shard_index, options.shard_count - 1))
+
+  sys.exit(main(options.output_dir, options.repeat, options.failed,
+                options.workers, options.gtest_color, options.gtest_filter,
+                options.gtest_also_run_disabled_tests, options.format,
+                options.print_test_times, options.shard_count,
+                options.shard_index, options.dump_json_test_results,
+                options.timeout, options.retry_failures))


### PR DESCRIPTION
What I tried to do here is to create some classes to store the information about the tests and test executions so they're not saved in multiple times, and move things from the global scope to functions to improve readability.
I also introduced the capability to retry failed tests.