### PR TITLE
Add TaskManager class and support to repeat failed tests.

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import cPickle
+import collections
 import errno
 import gzip
 import json
@@ -117,10 +118,10 @@ class Outputter(object):
 
 
 class Task(object):
-  def __init__(self, task_id, test_binary, test_name, test_command,
-               execution_number, last_execution_time, output_dir):
-    self.task_id = task_id
+  def __init__(self, test_binary, test_name, test_command, execution_number,
+               last_execution_time, output_dir):
     self.test_name = test_name
+    self.output_dir = output_dir
     self.test_binary = test_binary
     self.test_command = test_command
     self.execution_number = execution_number
@@ -130,6 +131,8 @@ class Task(object):
                                  self.__normalize(test_name), execution_number)
 
     self.log_file = os.path.join(output_dir, log_name)
+    self.task_id = (test_binary, test_name, execution_number)
+    self.test_id = (test_binary, test_name)
 
     self.exit_code = None
     self.runtime_ms = None
@@ -145,7 +148,6 @@ class Task(object):
     return re.sub('[^A-Za-z0-9]', '_', string)
 
   def run(self):
-    logger.log_start(self.task_id)
     begin = time.time()
     with open(self.log_file, 'w') as log:
       task = subprocess.Popen(self.test_command, stdout=log, stderr=log)
@@ -155,70 +157,101 @@ class Task(object):
         thread.exit()
     self.runtime_ms = int(1000 * (time.time() - begin))
     self.last_execution_time = None if self.exit_code else self.runtime_ms
-    test_results.log(self.test_name, {
-        "expected": "PASS",
-        "actual": "PASS" if self.exit_code == 0 else "FAIL",
-        "time": self.runtime_ms,
-    })
-    logger.log_exit(self.task_id)
 
 
-stdout_lock = threading.Lock()
+class TaskManager(object):
+  def __init__(self, times, logger, test_results):
+    self.times = times
+    self.logger = logger
+    self.test_results = test_results
 
-class FilterFormat:
+    self.passed = []
+    self.failed = []
+    self.started = {}
+    self.tasks_to_run = []
+    self.global_exit_code = 0
+    self.tasks_by_test = collections.defaultdict(list)
+    self.lock = threading.Lock()
+
+  def register(self, task):
+    self.tasks_to_run.append(task)
+    self.tasks_by_test[task.test_id].append(task.task_id)
+
+  def get_tasks_to_run(self):
+    tasks = sorted(self.tasks_to_run)
+    self.tasks_to_run = []
+    return tasks
+
+  def start_task(self, task):
+    with self.lock:
+      self.started[task.task_id] = task
+    task.run()
+    self.end_task(task)
+
+  def end_task(self, task):
+    self.logger.log_exit(task)
+    self.times.record_test_time(task.test_binary, task.test_name,
+                                task.last_execution_time)
+    if self.test_results:
+      test_results.log(task.test_name, task.runtime_ms,
+                       "PASS" if task.exit_code == 0 else "FAIL")
+
+    with self.lock:
+      self.started.pop(task.task_id)
+
+      execution_number = len(self.tasks_by_test[task.test_id])
+      execution_number_limit = options.repeat
+
+      if task.exit_code == 0:
+        self.passed.append(task)
+      else:
+        self.global_exit_code = task.exit_code
+        self.failed.append(task)
+        execution_number_limit = max(options.repeat, options.repeat_failed)
+
+      if execution_number <= execution_number_limit:
+        self.register(Task(task.test_binary, task.test_name,
+                           task.test_command, execution_number + 1,
+                           task.last_execution_time, task.output_dir))
+
+
+class FilterFormat(object):
   def __init__(self, output_dir):
     if sys.stdout.isatty():
       # stdout needs to be unbuffered since the output is interactive.
       sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
 
     self.output_dir = output_dir
-    self.out = Outputter(sys.stdout)
+
     self.total_tasks = 0
     self.finished_tasks = 0
-    self.global_exit_code = 0
+    self.out = Outputter(sys.stdout)
+    self.stdout_lock = threading.Lock()
 
-    self.tasks = []
-    self.passed = []
-    self.failed = []
-    self.started = set()
-
-  def move_to(self, destination_dir, task_ids):
+  def move_to(self, destination_dir, tasks):
     destination_dir = os.path.join(self.output_dir, destination_dir)
     os.makedirs(destination_dir)
-    for task_id in task_ids:
-        shutil.move(self.tasks[task_id].log_file, destination_dir)
-
-  def print_tests(self, message, task_ids):
-    self.out.permanent_line("%s (%s/%s):" %
-                            (message, len(task_ids), self.total_tasks))
-    tasks = sorted(
-        (self.tasks[task_id].test_binary, self.tasks[task_id].test_name)
-        for task_id in task_ids)
     for task in tasks:
-      self.out.permanent_line(" %s: %s" % task)
+        shutil.move(task.log_file, destination_dir)
 
-  def print_test_status(self, last_finished_task, time_ms):
-    self.out.transient_line("[%d/%d] %s (%d ms)"
-                            % (self.finished_tasks, self.total_tasks,
-                               last_finished_task, time_ms))
 
-  def log_start(self, task_id):
-    self.started.add(task_id)
+  def print_tests(self, message, tasks):
+    self.out.permanent_line("%s (%s/%s):" %
+                            (message, len(tasks), self.total_tasks))
+    for task in sorted(tasks):
+      runtime_ms = 'Interrupted'
+      if task.runtime_ms is not None:
+        runtime_ms = '%d ms' % task.runtime_ms
+      self.out.permanent_line("%11s: %s %s" % (
+          runtime_ms, task.test_binary, task.test_name))
 
-  def log_exit(self, task_id):
-    with stdout_lock:
-      self.started.remove(task_id)
+  def log_exit(self, task):
+    with self.stdout_lock:
       self.finished_tasks += 1
-
-      task = self.tasks[task_id]
-      self.print_test_status(task.test_name, task.runtime_ms)
-      times.record_test_time(task.test_binary, task.test_name,
-                             task.last_execution_time)
-      if task.exit_code == 0:
-        self.passed.append(task_id)
-      else:
-        self.global_exit_code = task.exit_code
-        self.failed.append(task_id)
+      self.out.transient_line("[%d/%d] %s (%d ms)"
+                              % (self.finished_tasks, self.total_tasks,
+                                 task.test_name, task.runtime_ms))
+      if task.exit_code != 0:
         with open(task.log_file) as f:
           for line in f.readlines():
             self.out.permanent_line(line.rstrip())
@@ -227,20 +260,11 @@ class FilterFormat:
           % (self.finished_tasks, self.total_tasks, task.test_name,
              task.exit_code, task.runtime_ms))
 
-  def log_tasks(self, tasks):
-    self.tasks = tasks
-    self.total_tasks = len(tasks)
+  def log_tasks(self, total_tasks):
+    self.total_tasks += total_tasks
     self.out.transient_line("[0/%d] Running tests..." % self.total_tasks)
 
-  def end(self):
-    if self.passed:
-      self.move_to('passed', self.passed)
-    if self.failed:
-      self.print_tests("FAILED TESTS", self.failed)
-      self.move_to('failed', self.failed)
-    if self.started:
-      self.print_tests("INTERRUPTED TESTS", self.started)
-      self.move_to('interrupted', self.started)
+  def flush(self):
     self.out.flush_transient_output()
 
 
@@ -262,23 +286,25 @@ class CollectTestResults(object):
         "tests": {},
     }
 
-  def log(self, test, result):
+  def log(self, test, runtime_ms, actual_result):
     with self.test_results_lock:
-      self.test_results['num_failures_by_type'][result['actual']] += 1
+      self.test_results['num_failures_by_type'][actual_result] += 1
       results = self.test_results['tests']
       for name in test.split('.'):
         results = results.setdefault(name, {})
-      results.update(result)
+
+      if results:
+        results['actual'] += ' ' + actual_result
+        results['times'].append(runtime_ms)
+      else:  # This is the first invocation of the test
+        results['actual'] = actual_result
+        results['times'] = [runtime_ms]
+        results['time'] = runtime_ms
+        results['expected'] = 'PASS'
 
   def dump_to_file_and_close(self):
     json.dump(self.test_results, self.json_dump_file)
     self.json_dump_file.close()
-
-class IgnoreTestResults(object):
-  def log(self, test, result):
-    pass
-  def dump_to_file_and_close(self):
-    pass
 
 class DummyTimer(object):
   def start(self):
@@ -337,7 +363,6 @@ class TestTimes(object):
 
 def find_tests(binaries, additional_args):
   test_count = 0
-  tasks = []
   for test_binary in binaries:
     command = [test_binary]
     if options.gtest_also_run_disabled_tests:
@@ -378,15 +403,10 @@ def find_tests(binaries, additional_args):
 
       test_command = command + ['--gtest_filter=' + test_name]
       if (test_count - options.shard_index) % options.shard_count == 0:
-        for execution_number in range(options.repeat):
-          task_id = len(tasks)
-          tasks.append(Task(task_id, test_binary, test_name, test_command,
-                            execution_number + 1, last_execution_time,
-                            options.output_dir))
+        task_manager.register(Task(test_binary, test_name, test_command, 1,
+                                   last_execution_time, options.output_dir))
 
       test_count += 1
-
-  return tasks
 
 
 def execute_tasks(tasks):
@@ -404,7 +424,7 @@ def execute_tasks(tasks):
             self.task_id += 1
           else:
             return
-        task.run()
+        task_manager.start_task(task)
 
   def start_daemon(func):
     t = threading.Thread(target=func)
@@ -437,8 +457,10 @@ parser = optparse.OptionParser(
 parser.add_option('-d', '--output_dir', type='string',
                   default=os.path.join(tempfile.gettempdir(), "gtest-parallel"),
                   help='output directory for test logs')
-parser.add_option('-r', '--repeat', type='int', default=1,
-                  help='repeat tests')
+parser.add_option('--repeat', type='int', default=0,
+                  help='Number of times to repeat all tests.')
+parser.add_option('--repeat_failed', type='int', default=0,
+                  help='Number of times to repeat failed tests.')
 parser.add_option('--failed', action='store_true', default=False,
                   help='run only failed and new tests')
 parser.add_option('-w', '--workers', type='int',
@@ -501,30 +523,43 @@ except OSError as e:
 timeout = (DummyTimer() if options.timeout is None
            else threading.Timer(options.timeout, sigint_handler.interrupt))
 
-test_results = (IgnoreTestResults() if options.dump_json_test_results is None
-                else CollectTestResults(options.dump_json_test_results))
+test_results = None
+if options.dump_json_test_results is not None:
+  test_results = CollectTestResults(options.dump_json_test_results)
 
 save_file = os.path.join(os.path.expanduser("~"), ".gtest-parallel-times")
 times = TestTimes(save_file)
-
 logger = FilterFormat(options.output_dir)
-tasks = find_tests(binaries, additional_args)
 
-logger.log_tasks(tasks)
+task_manager = TaskManager(times, logger, test_results)
 
-# Sort tests by falling runtime (with None, which is what we get for
-# new and failing tests, being considered larger than any real
-# runtime).
-execute_tasks(sorted(tasks))
+find_tests(binaries, additional_args)
 
-logger.end()
+tasks = task_manager.get_tasks_to_run()
+while tasks:
+  logger.log_tasks(len(tasks))
+  execute_tasks(tasks)
+  tasks = task_manager.get_tasks_to_run()
+
+if task_manager.passed:
+  logger.move_to('passed', task_manager.passed)
+  if options.print_test_times:
+    logger.print_tests('PASSED TESTS', task_manager.passed)
+
+if task_manager.failed:
+  logger.print_tests('FAILED TESTS', task_manager.failed)
+  logger.move_to('failed', task_manager.failed)
+
+if task_manager.started:
+  logger.print_tests('INTERRUPTED TESTS', task_manager.started.values())
+  logger.move_to('interrupted', task_manager.started.values())
+
+logger.flush()
 times.write_to_file(save_file)
-if options.print_test_times:
-  for task in sorted(tasks):
-    if task.last_execution_time is not None:
-      print "%8s %s" % ("%dms" % task.runtime_ms, task.test_name)
 
-test_results.dump_to_file_and_close()
+if test_results:
+  test_results.dump_to_file_and_close()
+
 if sigint_handler.got_sigint():
-  logger.global_exit_code = -signal.SIGINT
-sys.exit(logger.global_exit_code)
+  task_manager.global_exit_code = -signal.SIGINT
+sys.exit(task_manager.global_exit_code)

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -118,21 +118,23 @@ class Outputter(object):
 
 
 class Task(object):
-  def __init__(self, test_binary, test_name, test_command, execution_number,
+  def __init__(self, test_binary, test_name, test_command,
                last_execution_time, output_dir):
     self.test_name = test_name
     self.output_dir = output_dir
     self.test_binary = test_binary
     self.test_command = test_command
-    self.execution_number = execution_number
     self.last_execution_time = last_execution_time
 
+    self.test_id = (test_binary, test_name)
+
+    self.execution_number = task_manager.get_next_execution_number(self.test_id)
     log_name = '%s-%s-%s.log' % (self.__normalize(test_binary),
-                                 self.__normalize(test_name), execution_number)
+                                 self.__normalize(test_name),
+                                 self.execution_number)
 
     self.log_file = os.path.join(output_dir, log_name)
-    self.task_id = (test_binary, test_name, execution_number)
-    self.test_id = (test_binary, test_name)
+    self.task_id = (test_binary, test_name, self.execution_number)
 
     self.exit_code = None
     self.runtime_ms = None
@@ -165,30 +167,26 @@ class TaskManager(object):
     self.logger = logger
     self.test_results = test_results
 
+    self.global_exit_code = 0
+
     self.passed = []
     self.failed = []
     self.started = {}
-    self.tasks_to_run = []
-    self.global_exit_code = 0
-    self.tasks_by_test = collections.defaultdict(list)
+    self.execution_number = {}
+
     self.lock = threading.Lock()
 
-  def register(self, task):
-    self.tasks_to_run.append(task)
-    self.tasks_by_test[task.test_id].append(task.task_id)
+  def get_next_execution_number(self, test_id):
+    with self.lock:
+      next_execution_number = self.execution_number.setdefault(test_id, 1)
+      self.execution_number[test_id] += 1
+    return next_execution_number
 
-  def get_tasks_to_run(self):
-    tasks = sorted(self.tasks_to_run)
-    self.tasks_to_run = []
-    return tasks
-
-  def start_task(self, task):
+  def __register_start(self, task):
     with self.lock:
       self.started[task.task_id] = task
-    task.run()
-    self.end_task(task)
 
-  def end_task(self, task):
+  def __register_exit(self, task):
     self.logger.log_exit(task)
     self.times.record_test_time(task.test_binary, task.test_name,
                                 task.last_execution_time)
@@ -199,20 +197,25 @@ class TaskManager(object):
     with self.lock:
       self.started.pop(task.task_id)
 
-      execution_number = len(self.tasks_by_test[task.test_id])
-      execution_number_limit = options.repeat
-
       if task.exit_code == 0:
         self.passed.append(task)
       else:
-        self.global_exit_code = task.exit_code
         self.failed.append(task)
-        execution_number_limit = max(options.repeat, options.repeat_failed)
 
-      if execution_number <= execution_number_limit:
-        self.register(Task(task.test_binary, task.test_name,
-                           task.test_command, execution_number + 1,
-                           task.last_execution_time, task.output_dir))
+  def run_task(self, task):
+    for _ in range(options.retry_failed + 1):
+      self.__register_start(task)
+      task.run()
+      self.__register_exit(task)
+
+      if task.exit_code == 0:
+        break
+
+      task = Task(task.test_binary, task.test_name, task.test_command,
+                  task.last_execution_time, task.output_dir)
+
+    with self.lock:
+      self.global_exit_code = task.exit_code
 
 
 class FilterFormat(object):
@@ -242,8 +245,8 @@ class FilterFormat(object):
       runtime_ms = 'Interrupted'
       if task.runtime_ms is not None:
         runtime_ms = '%d ms' % task.runtime_ms
-      self.out.permanent_line("%11s: %s %s" % (
-          runtime_ms, task.test_binary, task.test_name))
+      self.out.permanent_line("%11s: %s %s (try #%d)" % (
+          runtime_ms, task.test_binary, task.test_name, task.execution_number))
 
   def log_exit(self, task):
     with self.stdout_lock:
@@ -363,6 +366,7 @@ class TestTimes(object):
 
 def find_tests(binaries, additional_args):
   test_count = 0
+  tasks = []
   for test_binary in binaries:
     command = [test_binary]
     if options.gtest_also_run_disabled_tests:
@@ -403,10 +407,13 @@ def find_tests(binaries, additional_args):
 
       test_command = command + ['--gtest_filter=' + test_name]
       if (test_count - options.shard_index) % options.shard_count == 0:
-        task_manager.register(Task(test_binary, test_name, test_command, 1,
-                                   last_execution_time, options.output_dir))
+        for _ in range(options.repeat):
+         tasks.append(Task(test_binary, test_name, test_command,
+                           last_execution_time, options.output_dir))
 
       test_count += 1
+
+  return tasks
 
 
 def execute_tasks(tasks):
@@ -424,7 +431,7 @@ def execute_tasks(tasks):
             self.task_id += 1
           else:
             return
-        task_manager.start_task(task)
+        task_manager.run_task(task)
 
   def start_daemon(func):
     t = threading.Thread(target=func)
@@ -457,9 +464,9 @@ parser = optparse.OptionParser(
 parser.add_option('-d', '--output_dir', type='string',
                   default=os.path.join(tempfile.gettempdir(), "gtest-parallel"),
                   help='output directory for test logs')
-parser.add_option('--repeat', type='int', default=0,
-                  help='Number of times to repeat all tests.')
-parser.add_option('--repeat_failed', type='int', default=0,
+parser.add_option('-r', '--repeat', type='int', default=1,
+                  help='Number of times to execute all the tests.')
+parser.add_option('--retry_failed', type='int', default=0,
                   help='Number of times to repeat failed tests.')
 parser.add_option('--failed', action='store_true', default=False,
                   help='run only failed and new tests')
@@ -533,13 +540,9 @@ logger = FilterFormat(options.output_dir)
 
 task_manager = TaskManager(times, logger, test_results)
 
-find_tests(binaries, additional_args)
-
-tasks = task_manager.get_tasks_to_run()
-while tasks:
-  logger.log_tasks(len(tasks))
-  execute_tasks(tasks)
-  tasks = task_manager.get_tasks_to_run()
+tasks = find_tests(binaries, additional_args)
+logger.log_tasks(len(tasks))
+execute_tasks(tasks)
 
 if task_manager.passed:
   logger.move_to('passed', task_manager.passed)
@@ -556,9 +559,7 @@ if task_manager.started:
 
 logger.flush()
 times.write_to_file(save_file)
-
-if test_results:
-  test_results.dump_to_file_and_close()
+test_results.dump_to_file_and_close()
 
 if sigint_handler.got_sigint():
   task_manager.global_exit_code = -signal.SIGINT

--- a/gtest-parallel
+++ b/gtest-parallel
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import cPickle
-import collections
 import errno
 import gzip
 import json
@@ -118,6 +117,15 @@ class Outputter(object):
 
 
 class Task(object):
+  """Stores information about a task (single execution of a test).
+
+  This class stores information about the test to be executed (gtest binary and
+  test name), and its result (log file, exit code and runtime).
+  Each task is uniquely identified by the gtest binary, the test name and an
+  execution number that increases each time the test is executed.
+  Additionaly we store the last execution time, so that next time the test is
+  executed, the slowest tests are run first.
+  """
   def __init__(self, test_binary, test_name, test_command,
                last_execution_time, output_dir):
     self.test_name = test_name
@@ -162,6 +170,13 @@ class Task(object):
 
 
 class TaskManager(object):
+  """Executes the tasks and stores the passed, failed and interrupted tasks.
+
+  When a task is run, this class keeps track if it passed, failed or was
+  interrupted. After a task finishes it calls the relevant functions of the
+  Logger, TestResults and TestTimes classes, and in case of failure, retries the
+  test as specified by the --retry_failed flag.
+  """
   def __init__(self, times, logger, test_results):
     self.times = times
     self.logger = logger
@@ -196,7 +211,6 @@ class TaskManager(object):
 
     with self.lock:
       self.started.pop(task.task_id)
-
       if task.exit_code == 0:
         self.passed.append(task)
       else:
@@ -211,6 +225,8 @@ class TaskManager(object):
       if task.exit_code == 0:
         break
 
+      # We need create a new Task instance. Each task represents a single test
+      # execution, with its own runtime, exit code and log file.
       task = Task(task.test_binary, task.test_name, task.test_command,
                   task.last_execution_time, task.output_dir)
 
@@ -408,8 +424,8 @@ def find_tests(binaries, additional_args):
       test_command = command + ['--gtest_filter=' + test_name]
       if (test_count - options.shard_index) % options.shard_count == 0:
         for _ in range(options.repeat):
-         tasks.append(Task(test_binary, test_name, test_command,
-                           last_execution_time, options.output_dir))
+          tasks.append(Task(test_binary, test_name, test_command,
+                            last_execution_time, options.output_dir))
 
       test_count += 1
 


### PR DESCRIPTION
TaskManager is responsible for dealing with times, logger and test_results, keeping track of what tasks have been executed and which tasks should be repeated.
The only semantic change should be that now, when we repeat the tasks with the --repeat flag, we wait until we finish executing the test to schedule the next execution. This is because running several instances of a test at the same time might cause problems.