### PR TITLE
Add --tests_times_output_dir option to override default location for …

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -567,7 +567,10 @@ def main():
     default_cache_path = os.path.join(os.path.expanduser('~'), '.cache')
     cache_path = os.environ.get('XDG_CACHE_HOME', default_cache_path)
 
-  save_file = os.path.join(cache_path, 'gtest-parallel')
+  if os.path.isdir(cache_path):
+    save_file = os.path.join(cache_path, 'gtest-parallel')
+  else:
+    save_file = os.path.join(os.path.expanduser('~'), '.gtest-parallel-times')
 
   times = TestTimes(save_file)
   logger = FilterFormat(options.output_dir)

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -518,10 +518,6 @@ def main():
   parser.add_option('--timeout', type='int', default=None,
                     help='Interrupt all remaining processes after the given '
                          'time (in seconds).')
-  parser.add_option('--tests_times_output_dir', type='string',
-                    default=os.path.expanduser('~'),
-                    help='output directory for saving results of previous '
-                         'tests\' runs')
 
   (options, binaries) = parser.parse_args()
 
@@ -563,8 +559,16 @@ def main():
   if options.dump_json_test_results is not None:
     test_results = CollectTestResults(options.dump_json_test_results)
 
-  save_file = os.path.join(options.tests_times_output_dir,
-                           '.gtest-parallel-times')
+  if sys.platform == 'win32':
+    default_cache_path = os.path.join(os.path.expanduser('~'), 'AppData', 'Local')
+    cache_path = os.environ.get('LOCALAPPDATA', default_cache_path)
+  else:
+    # We don't use xdg module since it's not a standard.
+    default_cache_path = os.path.join(os.path.expanduser('~'), '.cache')
+    cache_path = os.environ.get('XDG_CACHE_HOME', default_cache_path)
+
+  save_file = os.path.join(cache_path, 'gtest-parallel')
+
   times = TestTimes(save_file)
   logger = FilterFormat(options.output_dir)
 

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -518,6 +518,10 @@ def main():
   parser.add_option('--timeout', type='int', default=None,
                     help='Interrupt all remaining processes after the given '
                          'time (in seconds).')
+  parser.add_option('--tests_times_output_dir', type='string',
+                    default=os.path.expanduser('~'),
+                    help='output directory for saving results of previous '
+                         'tests\' runs')
 
   (options, binaries) = parser.parse_args()
 
@@ -559,7 +563,8 @@ def main():
   if options.dump_json_test_results is not None:
     test_results = CollectTestResults(options.dump_json_test_results)
 
-  save_file = os.path.join(os.path.expanduser("~"), ".gtest-parallel-times")
+  save_file = os.path.join(options.tests_times_output_dir,
+                           '.gtest-parallel-times')
   times = TestTimes(save_file)
   logger = FilterFormat(options.output_dir)
 


### PR DESCRIPTION
….gtest-parallel-times.