### PR TITLE
Add --run_test_cases command line option for running whole test cases in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,10 @@ your friends here.
 
 ## Running tests cases in parallel
 
-Sometimes tests in test case make system-wide changes in their
-`SetUp()/SetUpTestCase()` methods. Examples of such changes are opening sockets
-on fixed address:port, writing to files at fixed location, etc. Running such
-code in parallel processes most likely will fail. In order to avoid this
-situation `gtest-parallel` provides `--serialize_test_cases` capability.
-
-    # ./gtest-parallel --serialize_test_cases path/to/binary
-
-This option can be used along with other `gtest-parallel` options and it ensures
-that tests from the same test case are never run in parallel. Naturally this
-works as long as other tests cases do not do the same globally visible things.
+Sometimes tests within a single test case use globally-shared resources (instead
+of temporary files or fake/mock objects) and cannot be run in parallel.
+Examples of such changes are opening sockets on fixed `address:port`, writing
+to files at fixed location, etc. Running such tests in parallel will either fail
+or be flaky. For test binaries where tests are not self contained, but test
+cases are, --serialize_test_cases can be provided to prevent them from running
+in parallel, while still benefiting from parallel speedup between test cases.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,17 @@ Note that repeated tests do run concurrently with themselves for efficiency, and
 as such they have problem writing to hard-coded files, even if they are only
 used by that single test. `tmpfile()` and similar library functions are often
 your friends here.
+
+## Running tests cases in parallel
+
+Sometimes tests in test case make system-wide changes in their
+`SetUp()/SetUpTestCase()` methods. Examples of such changes are opening sockets
+on fixed address:port, writing to files at fixed location, etc. Running such
+code in parallel processes most likely will fail. In order to avoid this
+situation `gtest-parallel` provides `--serialize_test_cases` capability.
+
+    # ./gtest-parallel --serialize_test_cases path/to/binary
+
+This option can be used along with other `gtest-parallel` options and it ensures
+that tests from the same test case are never run in parallel. Naturally this
+works as long as other tests cases do not do the same globally visible things.

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -558,8 +558,8 @@ def main():
                     help='Interrupt all remaining processes after the given '
                          'time (in seconds).')
   parser.add_option('--serialize_test_cases', action='store_true',
-                    default=False, help='make sure that tests from the same '
-                                        'test case are never run in parallel')
+                    default=False, help='Do not run tests from the same test '
+                                        'case in parallel.')
 
   (options, binaries) = parser.parse_args()
 

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -16,9 +16,12 @@ import collections
 import contextlib
 import gtest_parallel
 import os.path
+import random
 import shutil
 import sys
 import tempfile
+import threading
+import time
 import unittest
 
 
@@ -298,6 +301,134 @@ class TestSaveFilePath(unittest.TestCase):
                               {'LOCALAPPDATA': os.path.realpath(__file__)}):
         self.assertEqual(os.path.join(temp_dir, '.gtest-parallel-times'),
                          gtest_parallel.get_save_file_path())
+
+
+class TestSerializeTestCases(unittest.TestCase):
+  class TaskManagerMock(object):
+    def __init__(self, group_checker):
+      self.group_checker = group_checker
+      self.check_lock = threading.Lock()
+
+    def run_task(self, task):
+      test_group = task.test_name.split('.')[0]
+
+      with self.check_lock:
+        self.group_checker.add(test_group)
+
+      # Delay as if real test were run.
+      time.sleep(0.001 * task.execution_number)
+
+      with self.check_lock:
+        self.group_checker.remove(test_group)
+
+  def test_running_parallel_test_cases_with_multiple_executions(self):
+    max_number_of_test_cases = 4
+    max_number_of_tests_per_test_case = 32
+    max_number_of_tests_executions = 16
+    max_number_of_workers = 16
+
+    tasks = []
+    for test_case in range(max_number_of_test_cases):
+      for test_name in range(max_number_of_tests_per_test_case):
+        # All arguments for gtest_parallel.Task except for test_name and
+        # execution_number are fake.
+        test_name = 'TestCase{}.test{}'.format(test_case, test_name)
+        execution_number = random.randint(1, max_number_of_tests_executions)
+
+        tasks.append(gtest_parallel.Task(
+          'path/to/binary', test_name, ['path/to/binary', '--gtest_filter=*'],
+          execution_number, None, 'path/to/output'))
+
+    class GroupChecker(object):
+      def __init__(self, ut_self):
+        self.ut_self = ut_self
+        self.running_groups = set()
+
+      def add(self, test_group):
+        self.ut_self.assertNotIn(test_group, self.running_groups)
+
+        self.running_groups.add(test_group)
+
+      def remove(self, test_group):
+        self.running_groups.remove(test_group)
+
+    task_manager = TestSerializeTestCases.TaskManagerMock(GroupChecker(self))
+
+    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
+                                 task_manager, None, True)
+
+  def test_running_parallel_test_cases_with_repeats(self):
+    max_number_of_test_cases = 4
+    max_number_of_tests_per_test_case = 32
+    max_number_of_repeats = 16
+    max_number_of_workers = 16
+
+    tasks = []
+    for test_case in range(max_number_of_test_cases):
+      for test_name in range(max_number_of_tests_per_test_case):
+        # All arguments for gtest_parallel.Task except for test_name are fake.
+        test_name = 'TestCase{}.test{}'.format(test_case, test_name)
+
+        for repeat in range(random.randint(1, max_number_of_repeats)):
+          tasks.append(gtest_parallel.Task(
+            'path/to/binary', test_name, ['path/to/binary', '--gtest_filter=*'],
+            1, None, 'path/to/output'))
+
+    class GroupChecker(object):
+      def __init__(self, ut_self):
+        self.ut_self = ut_self
+        self.running_groups = set()
+
+      def add(self, test_group):
+        self.ut_self.assertNotIn(test_group, self.running_groups)
+
+        self.running_groups.add(test_group)
+
+      def remove(self, test_group):
+        self.running_groups.remove(test_group)
+
+    task_manager = TestSerializeTestCases.TaskManagerMock(GroupChecker(self))
+
+    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
+                                 task_manager, None, True)
+
+  def test_running_parallel_tests(self):
+    max_number_of_test_cases = 4
+    max_number_of_tests_per_test_case = 128
+    max_number_of_workers = 16
+
+    tasks = []
+    for test_case in range(max_number_of_test_cases):
+      for test_name in range(max_number_of_tests_per_test_case):
+        # All arguments for gtest_parallel.Task except for test_name are fake.
+        test_name = 'TestCase{}.test{}'.format(test_case, test_name)
+
+        tasks.append(gtest_parallel.Task(
+          'path/to/binary', test_name, ['path/to/binary', '--gtest_filter=*'],
+          1, None, 'path/to/output'))
+
+    class GroupChecker(object):
+      def __init__(self, ut_self):
+        self.ut_self = ut_self
+        self.running_groups = []
+        self.had_running_parallel_groups = False
+
+      def add(self, test_group):
+        self.running_groups.append(test_group)
+
+      def remove(self, test_group):
+        self.running_groups.remove(test_group)
+
+        self.had_running_parallel_groups = (
+          self.had_running_parallel_groups or test_group in self.running_groups)
+
+    checker = GroupChecker(self)
+    task_manager = TestSerializeTestCases.TaskManagerMock(checker)
+
+    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
+                                 task_manager, None, False)
+
+    self.assertTrue(checker.had_running_parallel_groups)
 
 
 if __name__ == '__main__':

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -327,74 +327,52 @@ class TestSerializeTestCases(unittest.TestCase):
       with self.check_lock:
         self.running_groups.remove(test_group)
 
-  def _generate_tasks(self, number_of_test_cases,
-                      number_of_tests_per_test_case,
-                      number_of_repeats):
+  def _execute_tasks(self, max_number_of_test_cases,
+                     max_number_of_tests_per_test_case,
+                     max_number_of_repeats, max_number_of_workers,
+                     serialize_test_cases):
     tasks = []
-    for test_case in range(number_of_test_cases):
-      for test_name in range(number_of_tests_per_test_case):
+    for test_case in range(max_number_of_test_cases):
+      for test_name in range(max_number_of_tests_per_test_case):
         # All arguments for gtest_parallel.Task except for test_name are fake.
         test_name = 'TestCase{}.test{}'.format(test_case, test_name)
 
-        for execution_number in range(random.randint(1, number_of_repeats)):
+        for execution_number in range(random.randint(1, max_number_of_repeats)):
           tasks.append(gtest_parallel.Task(
             'path/to/binary', test_name, ['path/to/binary', '--gtest_filter=*'],
             execution_number + 1, None, 'path/to/output'))
 
-    return tasks
+    expected_tasks_number = len(tasks)
+
+    task_manager = TestSerializeTestCases.TaskManagerMock()
+
+    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
+                                 task_manager, None, serialize_test_cases)
+
+    self.assertEqual(serialize_test_cases,
+                     not task_manager.had_running_parallel_groups)
+    self.assertEqual(expected_tasks_number, task_manager.total_tasks_run)
 
   def test_running_parallel_test_cases_without_repeats(self):
-    max_number_of_test_cases = 4
-    max_number_of_tests_per_test_case = 32
-    max_number_of_workers = 16
-
-    tasks = self._generate_tasks(max_number_of_test_cases,
-                                 max_number_of_tests_per_test_case, 1)
-    expected_tasks_number = len(tasks)
-
-    task_manager = TestSerializeTestCases.TaskManagerMock()
-
-    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
-                                 task_manager, None, True)
-
-    self.assertFalse(task_manager.had_running_parallel_groups)
-    self.assertEqual(expected_tasks_number, task_manager.total_tasks_run)
+    self._execute_tasks(max_number_of_test_cases=4,
+                        max_number_of_tests_per_test_case=32,
+                        max_number_of_repeats=1,
+                        max_number_of_workers=16,
+                        serialize_test_cases=True)
 
   def test_running_parallel_test_cases_with_repeats(self):
-    max_number_of_test_cases = 4
-    max_number_of_tests_per_test_case = 32
-    max_number_of_repeats = 8
-    max_number_of_workers = 16
-
-    tasks = self._generate_tasks(max_number_of_test_cases,
-                                 max_number_of_tests_per_test_case,
-                                 max_number_of_repeats)
-    expected_tasks_number = len(tasks)
-
-    task_manager = TestSerializeTestCases.TaskManagerMock()
-
-    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
-                                 task_manager, None, True)
-
-    self.assertFalse(task_manager.had_running_parallel_groups)
-    self.assertEqual(expected_tasks_number, task_manager.total_tasks_run)
+    self._execute_tasks(max_number_of_test_cases=4,
+                        max_number_of_tests_per_test_case=32,
+                        max_number_of_repeats=4,
+                        max_number_of_workers=16,
+                        serialize_test_cases=True)
 
   def test_running_parallel_tests(self):
-    max_number_of_test_cases = 4
-    max_number_of_tests_per_test_case = 128
-    max_number_of_workers = 16
-
-    tasks = self._generate_tasks(max_number_of_test_cases,
-                                 max_number_of_tests_per_test_case, 1)
-    expected_tasks_number = len(tasks)
-
-    task_manager = TestSerializeTestCases.TaskManagerMock()
-
-    gtest_parallel.execute_tasks(tasks, max_number_of_workers,
-                                 task_manager, None, False)
-
-    self.assertTrue(task_manager.had_running_parallel_groups)
-    self.assertEqual(expected_tasks_number, task_manager.total_tasks_run)
+    self._execute_tasks(max_number_of_test_cases=4,
+                        max_number_of_tests_per_test_case=128,
+                        max_number_of_repeats=1,
+                        max_number_of_workers=16,
+                        serialize_test_cases=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes it is safer to run whole test cases instead of individual tests.