### PR TITLE
Race in TestTimes loading/saving

### DIFF
--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -376,16 +376,18 @@ class TestSerializeTestCases(unittest.TestCase):
 
 class TestTestTimes(unittest.TestCase):
   def test_race_in_test_times_load_save(self):
-    max_number_of_workers = 16
-    max_numver_of_read_write_cycles = 128
+    max_number_of_workers = 1
+    max_number_of_read_write_cycles = 64
     test_times_file_name = 'test_times.pickle'
 
     def start_worker(save_file):
       def test_times_worker():
-        for _ in range(max_numver_of_read_write_cycles):
+        for cnt in range(max_number_of_read_write_cycles):
           times = gtest_parallel.TestTimes(save_file)
+          self.assertEqual(cnt, len(times._TestTimes__times))
 
-          times.record_test_time('path/to/binary', 'TestFoo.testBar', 1000)
+          times.record_test_time('path/to/binary{}'.format(cnt),
+                                 'TestFoo.testBar', 1000)
 
           times.write_to_file(save_file)
 


### PR DESCRIPTION
The race happens when there are several gtest-parallel instances are run in parallel.

For us it happens because we have a number of components each with own tests and we have targets in our build system which allow running tests for each component independently. Running all tests (for which we also have aggregate target) each time takes substantial amount of time and is not very convenient during active development. So, something like this: `make -j3 RunFooComponentTests RunBarComponentTests RunBazComponentTests` spawns for us 3 python processes of gtest-parallel running tests for FooComponent, BarComponent, and BazComponent respectively.

Now, how shall we fix it? As far as I understand the only portable and reliable way in python is a lock file. What do you think?

Also, currently suppressing/catching `struct.error` is acceptable for us but, in general, this is not how TestTimes is supposed to work.