### PR TITLE
Use unique path for default output directory

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -599,7 +599,7 @@ def main():
       usage = 'usage: %prog [options] binary [binary ...] -- [additional args]')
 
   parser.add_option('-d', '--output_dir', type='string',
-                    default=os.path.join(tempfile.gettempdir(), "gtest-parallel"),
+                    default=tempfile.mkdtemp('gtest-parallel')),
                     help='output directory for test logs')
   parser.add_option('-r', '--repeat', type='int', default=1,
                     help='Number of times to execute all the tests.')


### PR DESCRIPTION
The default output directory was the same across all gtest-parallel invocations.  This means that running gtest-parallel in parallel would cause the different instances to mess with each others' files.  This patch instead uses tempfile to generate a unique temporary directory whose name starts with "gtest-parallel".