### PR TITLE
Add test which exhibits problem with log file paths on windows

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -167,9 +167,9 @@ class Task(object):
     self.test_id = (test_binary, test_name)
     self.task_id = (test_binary, test_name, self.execution_number)
 
-    log_name = '%s-%s-%s.log' % (self.__normalize(test_binary),
-                                 self.__normalize(test_name),
-                                 self.execution_number)
+    log_name = '%s-%s-%s.log' % (
+      Task._normalize(os.path.basename(test_binary)),
+      Task._normalize(test_name), self.execution_number)
 
     self.log_file = os.path.join(output_dir, log_name)
 
@@ -180,7 +180,8 @@ class Task(object):
       return False
     return self.last_execution_time > other.last_execution_time
 
-  def __normalize(self, string):
+  @staticmethod
+  def _normalize(string):
     return re.sub('[^A-Za-z0-9]', '_', string)
 
   def run(self):

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -167,11 +167,8 @@ class Task(object):
     self.test_id = (test_binary, test_name)
     self.task_id = (test_binary, test_name, self.execution_number)
 
-    log_name = '%s-%s-%s.log' % (
-      Task._normalize(os.path.basename(test_binary)),
-      Task._normalize(test_name), self.execution_number)
-
-    self.log_file = os.path.join(output_dir, log_name)
+    self.log_file = Task._logname(self.output_dir, self.test_binary,
+                                  test_name, self.execution_number)
 
   def __lt__(self, other):
     if self.last_execution_time is None:
@@ -183,6 +180,13 @@ class Task(object):
   @staticmethod
   def _normalize(string):
     return re.sub('[^A-Za-z0-9]', '_', string)
+
+  @staticmethod
+  def _logname(output_dir, test_binary, test_name, execution_number):
+    log_name = '%s-%s-%d.log' % (Task._normalize(os.path.basename(test_binary)),
+                                 Task._normalize(test_name), execution_number)
+
+    return os.path.join(output_dir, log_name)
 
   def run(self):
     begin = time.time()
@@ -288,7 +292,6 @@ class FilterFormat(object):
     os.makedirs(destination_dir)
     for task in tasks:
         shutil.move(task.log_file, destination_dir)
-
 
   def print_tests(self, message, tasks, print_try_number):
     self.out.permanent_line("%s (%s/%s):" %

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -414,6 +414,28 @@ class TestTestTimes(unittest.TestCase):
 
 
 class TestFilterFormat(unittest.TestCase):
+  def test_log_file_names(self):
+    self.assertEqual(
+      'bin-Test_case-100.log',
+      gtest_parallel.Task._logname('', 'bin', 'Test.case', 100))
+
+    self.assertEqual(
+      '../a/b/bin-Test_case_2-1.log',
+      gtest_parallel.Task._logname('../a/b', '../bin', 'Test.case/2', 1))
+
+    self.assertEqual(
+      '../a/b/bin-Test_case_2-5.log',
+      gtest_parallel.Task._logname('../a/b', '/c/d/bin', 'Test.case/2', 5))
+
+    self.assertEqual(
+      '/a/b/bin-Instantiation_Test_case_2-3.log',
+      gtest_parallel.Task._logname('/a/b', '../c/bin',
+                                   'Instantiation/Test.case/2', 3))
+
+    self.assertEqual(
+      '/a/b/bin-Test_case-1.log',
+      gtest_parallel.Task._logname('/a/b', '/c/d/bin', 'Test.case', 1))
+
   def test_on_windows_long_file_names_in_move_to(self):
     destination_subdir = 'interrupted'
     max_path = 260

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -18,6 +18,7 @@ import gtest_parallel
 import os.path
 import random
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -410,6 +411,21 @@ class TestTestTimes(unittest.TestCase):
       finally:
         for worker in workers:
           worker.join()
+
+
+class TestFilterFormat(unittest.TestCase):
+  @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+  def test_long_file_names_in_move_to(self):
+    class Task(object):
+      def __init__(self, length, dest):
+        self.log_file = os.path.join(dest, ('a' * length) + '.log')
+        with open(self.log_file, 'wb'):
+          pass
+
+    with guard_temp_dir() as temp_dir:
+      ff = gtest_parallel.FilterFormat(temp_dir)
+      tasks = [Task(l, temp_dir) for l in range(1, 255 - len(temp_dir))]
+      ff.move_to('passed', tasks)
 
 
 if __name__ == '__main__':

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -415,26 +415,36 @@ class TestTestTimes(unittest.TestCase):
 
 class TestFilterFormat(unittest.TestCase):
   def test_log_file_names(self):
+    def root():
+      return 'c:/' if sys.platform == 'win32' else '/'
+
     self.assertEqual(
       'bin-Test_case-100.log',
       gtest_parallel.Task._logname('', 'bin', 'Test.case', 100))
 
     self.assertEqual(
-      '../a/b/bin-Test_case_2-1.log',
-      gtest_parallel.Task._logname('../a/b', '../bin', 'Test.case/2', 1))
+      os.path.join('..', 'a', 'b', 'bin-Test_case_2-1.log'),
+      gtest_parallel.Task._logname(os.path.join('..', 'a', 'b'),
+                                   os.path.join('..', 'bin'),
+                                   'Test.case/2', 1))
 
     self.assertEqual(
-      '../a/b/bin-Test_case_2-5.log',
-      gtest_parallel.Task._logname('../a/b', '/c/d/bin', 'Test.case/2', 5))
+      os.path.join('..', 'a', 'b', 'bin-Test_case_2-5.log'),
+      gtest_parallel.Task._logname(os.path.join('..', 'a', 'b'),
+                                   os.path.join(root(), 'c', 'd', 'bin'),
+                                   'Test.case/2', 5))
 
     self.assertEqual(
-      '/a/b/bin-Instantiation_Test_case_2-3.log',
-      gtest_parallel.Task._logname('/a/b', '../c/bin',
+      os.path.join(root(), 'a', 'b', 'bin-Instantiation_Test_case_2-3.log'),
+      gtest_parallel.Task._logname(os.path.join(root(), 'a', 'b'),
+                                   os.path.join('..', 'c', 'bin'),
                                    'Instantiation/Test.case/2', 3))
 
     self.assertEqual(
-      '/a/b/bin-Test_case-1.log',
-      gtest_parallel.Task._logname('/a/b', '/c/d/bin', 'Test.case', 1))
+      os.path.join(root(), 'a', 'b', 'bin-Test_case-1.log'),
+      gtest_parallel.Task._logname(os.path.join(root(), 'a', 'b'),
+                                   os.path.join(root(), 'c', 'd', 'bin'),
+                                   'Test.case', 1))
 
   def test_on_windows_long_file_names_in_move_to(self):
     destination_subdir = 'interrupted'


### PR DESCRIPTION
The problem is that when we create log file the file path can be shorter than MAX_PATH in Windows (260 characters) but when we move it to 'passed'/'failed'/'interrupted' subdirectory the path can become longer and in such cases we miserably fail just before finishing gtest_parallel.

There are many options for fixing this issue but all of them have flaws. For example, for me it's ok to reduce log file name by removing test_binary from it.