### PR TITLE
Replace __lt__ instance with sorting key.

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -169,12 +169,16 @@ class Task(object):
     self.log_file = Task._logname(self.output_dir, self.test_binary,
                                   test_name, self.execution_number)
 
-  def __lt__(self, other):
-    if self.last_execution_time is None:
-      return True
-    if other.last_execution_time is None:
-      return False
-    return self.last_execution_time > other.last_execution_time
+  def __sorting_key(self):
+    # Unseen or failing tests (both missing execution time) take precedence over
+    # execution time.
+    return (1 if self.last_execution_time is None else 0,
+            self.last_execution_time)
+
+  def __cmp__(self, other):
+    # Reverse sorting order, we want larger items (longer runtimes or
+    # unseen/failing tests) first to run longer tests first.
+    return -cmp(self.__sorting_key(), other.__sorting_key())
 
   @staticmethod
   def _normalize(string):

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -171,14 +171,13 @@ class Task(object):
 
   def __sorting_key(self):
     # Unseen or failing tests (both missing execution time) take precedence over
-    # execution time.
+    # execution time. Tests are greater (seen as slower) when missing times so
+    # that they are executed first.
     return (1 if self.last_execution_time is None else 0,
             self.last_execution_time)
 
   def __cmp__(self, other):
-    # Reverse sorting order, we want larger items (longer runtimes or
-    # unseen/failing tests) first to run longer tests first.
-    return -cmp(self.__sorting_key(), other.__sorting_key())
+    return cmp(self.__sorting_key(), other.__sorting_key())
 
   @staticmethod
   def _normalize(string):
@@ -535,7 +534,9 @@ def find_tests(binaries, additional_args, options, times):
 
       test_count += 1
 
-  return sorted(tasks)
+  # Sort the tasks to run the slowest tests first, so that faster ones can be
+  # finished in parallel.
+  return sorted(tasks, reverse=True)
 
 
 def execute_tasks(tasks, pool_size, task_manager,

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -393,10 +393,10 @@ class TestFindTests(unittest.TestCase):
         test_data.keys(), [], options, TestTimesMock(self, test_data))
     return tasks, popen_mock
 
-  def test_tasks_are_sorted(self):
+  def test_tasks_are_sorted_in_descending_order(self):
     tasks, _ = self._call_find_tests(
         self.MULTIPLE_BINARIES_MULTIPLE_TESTS_ONE_FAILURE)
-    self.assertEqual(tasks, sorted(tasks))
+    self.assertEqual(tasks, sorted(tasks, reverse=True))
 
   def test_does_not_run_disabled_tests_by_default(self):
     tasks, popen_mock = self._call_find_tests(

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -393,10 +393,11 @@ class TestFindTests(unittest.TestCase):
         test_data.keys(), [], options, TestTimesMock(self, test_data))
     return tasks, popen_mock
 
-  def test_tasks_are_sorted_in_descending_order(self):
+  def test_tasks_are_sorted(self):
     tasks, _ = self._call_find_tests(
         self.MULTIPLE_BINARIES_MULTIPLE_TESTS_ONE_FAILURE)
-    self.assertEqual(tasks, sorted(tasks, reverse=True))
+    self.assertEqual([task.last_execution_time for task in tasks],
+                     [None, 4, 4, 3, 2])
 
   def test_does_not_run_disabled_tests_by_default(self):
     tasks, popen_mock = self._call_find_tests(


### PR DESCRIPTION
Missing test time (unseen tests or failing runs) still take precedence
over finished tests. This format is easier to read and removes the issue
where we only supplied one of the rich comparison methods. Now we supply
none.