### PR TITLE
Add --print_test_summary option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ as such they have problem writing to hard-coded files, even if they are only
 used by that single test. `tmpfile()` and similar library functions are often
 your friends here.
 
+### Flakiness Summaries
+
+Especially for disabled tests, you might wonder how stable a test seems before
+trying to reenable it. `gtest-parallel` provides a `--print_test_summary` flag
+that can be used to generate passed/failed statistics per test.
+
+For example, to try all disabled tests and see how stable they are:
+
+    $ ./gtest-parallel path/to/binary... -r1000 --gtest_filter=*.DISABLED_* --gtest_also_run_disabled_tests --print_test_summary
+
+Which will generate something like this at the end of the run:
+
+    SUMMARY:
+      path/to/binary... Foo.DISABLED_Bar passed 0 / 1000 times.
+      path/to/binary... FooBar.DISABLED_Baz passed 30 / 1000 times.
+      path/to/binary... Foo.DISABLED_Baz passed 1000 / 1000 times.
+
 ## Running Tests Within Test Cases Sequentially
 
 Sometimes tests within a single test case use globally-shared resources

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -293,7 +293,7 @@ class FilterFormat(object):
     destination_dir = os.path.join(self.output_dir, destination_dir)
     os.makedirs(destination_dir)
     for task in tasks:
-        shutil.move(task.log_file, destination_dir)
+      shutil.move(task.log_file, destination_dir)
 
   def print_tests(self, message, tasks, print_try_number):
     self.out.permanent_line("%s (%s/%s):" %
@@ -324,6 +324,35 @@ class FilterFormat(object):
   def log_tasks(self, total_tasks):
     self.total_tasks += total_tasks
     self.out.transient_line("[0/%d] Running tests..." % self.total_tasks)
+
+  def summarize(self, passed_tasks, failed_tasks, interrupted_tasks):
+    stats = {}
+    def add_stats(stats, task, idx):
+      task_key = (task.test_binary, task.test_name)
+      if not task_key in stats:
+        # (passed, failed, interrupted) task_key is added as tie breaker to get
+        # alphabetic sorting on equally-stable tests
+        stats[task_key] = [0, 0, 0, task_key]
+      stats[task_key][idx] += 1
+
+    for task in passed_tasks:
+      add_stats(stats, task, 0)
+    for task in failed_tasks:
+      add_stats(stats, task, 1)
+    for task in interrupted_tasks:
+      add_stats(stats, task, 2)
+
+    self.out.permanent_line("SUMMARY:")
+    for task_key in sorted(stats, key=stats.__getitem__):
+      (num_passed, num_failed, num_interrupted, _) = stats[task_key]
+      (test_binary, task_name) = task_key
+      self.out.permanent_line(
+          "  %s %s passed %d / %d times%s." %
+              (test_binary, task_name, num_passed,
+               num_passed + num_failed + num_interrupted,
+               "" if num_interrupted == 0 else (" (%d interrupted)" % num_interrupted)))
+
+
 
   def flush(self):
     self.out.flush_transient_output()
@@ -636,6 +665,9 @@ def default_options_parser():
   parser.add_option('--serialize_test_cases', action='store_true',
                     default=False, help='Do not run tests from the same test '
                                         'case in parallel.')
+  parser.add_option('--print_test_summary', action='store_true', default=False,
+                    help='Summarize results per test at the end, useful for '
+                         'flakiness testing.')
   return parser
 
 
@@ -722,6 +754,10 @@ def main():
     logger.print_tests(
         'INTERRUPTED TESTS', task_manager.started.values(), print_try_number)
     logger.move_to('interrupted', task_manager.started.values())
+
+  if options.print_test_summary:
+    logger.summarize(task_manager.passed, task_manager.failed,
+                     task_manager.started.values())
 
   logger.flush()
   times.write_to_file(save_file)


### PR DESCRIPTION
Useful for flakiness stats, prints X / Y passed stats at end of run.