### PR TITLE
Handle errors better when obtaining tests list.

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -526,9 +526,9 @@ def find_tests(binaries, additional_args, options, times):
       list_command += ['--gtest_filter=' + options.gtest_filter]
 
     try:
-      test_list = subprocess.Popen(list_command,
-                                   stdout=subprocess.PIPE).communicate()[0]
-    except OSError as e:
+      test_list = subprocess.check_output(list_command,
+                                          stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
       sys.exit("%s: %s" % (test_binary, str(e)))
 
     command += additional_args + ['--gtest_color=' + options.gtest_color]

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -352,8 +352,6 @@ class FilterFormat(object):
                num_passed + num_failed + num_interrupted,
                "" if num_interrupted == 0 else (" (%d interrupted)" % num_interrupted)))
 
-
-
   def flush(self):
     self.out.flush_transient_output()
 

--- a/gtest_parallel_mocks.py
+++ b/gtest_parallel_mocks.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections
-import contextlib
-import gtest_parallel
-import os
-import shutil
-import tempfile
 import threading
 import time
 
@@ -149,19 +144,12 @@ class TaskMock(object):
     pass
 
 
-class PopenMock(object):
-  class _SubprocessMock(object):
-    def __init__(self, stdout=""):
-      self.stdout = stdout
-
-    def communicate(self):
-      return [self.stdout]
-
+class SubprocessMock(object):
   def __init__(self, test_data=None):
     self._test_data = test_data
     self.last_invocation = None
 
-  def __call__(self, command, stdout=None):
+  def __call__(self, command, **kwargs):
     self.last_invocation = command
     binary = command[0]
     test_list = []
@@ -170,4 +158,4 @@ class PopenMock(object):
       test_list.append(test_group + ".")
       for test in sorted(tests):
         test_list.append("  " + test)
-    return self._SubprocessMock('\n'.join(test_list))
+    return '\n'.join(test_list)


### PR DESCRIPTION
If test runner is broken and crashes even before it handles `--gtest_list_tests` then gtest-parallel should probably fail too. Currently, it says `[0/0] Running tests...` and returns success status.