### PR TITLE
Run when gtest_parallel.py is invoked directly.

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -763,3 +763,6 @@ def main():
     return -signal.SIGINT
 
   return task_manager.global_exit_code
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
If gtest_parallel.py is invoked directly instead of gtest-parallel (fair
mistake), just run the script instead of silently failing or erroring.

Fixes #56.