### PR TITLE
(Fix issue #57) Disable by default log files saving

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -690,8 +690,10 @@ def main():
   parser = default_options_parser()
   (options, binaries) = parser.parse_args()
 
-  if not options.output_dir or not os.path.isdir(options.output_dir):
-    options.output_dir = None
+  if (options.output_dir is not None and
+      not os.path.isdir(options.output_dir)):
+    parser.error('--output_dir value must be an existing directory, '
+                 'current value is "%s"' % options.output_dir)
 
   # Append gtest-parallel-logs to log output, this is to avoid deleting user
   # data if an user passes a directory where files are already present. If a

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -184,8 +184,10 @@ class Task(object):
 
   @staticmethod
   def _logname(output_dir, test_binary, test_name, execution_number):
+    # Store logs to temporary files if there is no output_dir.
     if output_dir is None:
-      (log_handle, log_name) = tempfile.mkstemp(prefix='tmpGP_', suffix=".log")
+      (log_handle, log_name) = tempfile.mkstemp(prefix='gtest_parallel_',
+                                                suffix=".log")
       os.close(log_handle)
       return log_name
 
@@ -687,11 +689,15 @@ def main():
 
   parser = default_options_parser()
   (options, binaries) = parser.parse_args()
+
+  if not options.output_dir or not os.path.isdir(options.output_dir):
+    options.output_dir = None
+
   # Append gtest-parallel-logs to log output, this is to avoid deleting user
   # data if an user passes a directory where files are already present. If a
   # user specifies --output_dir=Docs/, we'll create Docs/gtest-parallel-logs
   # and clean that directory out on startup, instead of nuking Docs/.
-  if options.output_dir is not None:
+  if options.output_dir:
     options.output_dir = os.path.join(options.output_dir,
                                       'gtest-parallel-logs')
 
@@ -714,7 +720,7 @@ def main():
   assert len(unique_binaries) == len(binaries), (
       "All test binaries must have an unique basename.")
 
-  if options.output_dir is not None:
+  if options.output_dir:
     # Remove files from old test runs.
     if os.path.isdir(options.output_dir):
       shutil.rmtree(options.output_dir)

--- a/gtest_parallel_mocks.py
+++ b/gtest_parallel_mocks.py
@@ -133,6 +133,10 @@ class TaskMock(object):
     self.exit_code = test_data['exit_code'][execution_number]
     self.last_execution_time = (
         test_data['last_execution_time'][execution_number])
+    if 'log_file' in test_data:
+      self.log_file = test_data['log_file'][execution_number]
+    else:
+      self.log_file = None
     self.test_command = None
     self.output_dir = None
 

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -315,8 +315,8 @@ class TestTask(unittest.TestCase):
       return 'C:\\' if sys.platform == 'win32' else '/'
 
     self.assertEqual(
-      'bin-Test_case-100.log',
-      gtest_parallel.Task._logname('', 'bin', 'Test.case', 100))
+      './bin-Test_case-100.log',
+      gtest_parallel.Task._logname('.', 'bin', 'Test.case', 100))
 
     self.assertEqual(
       os.path.join('..', 'a', 'b', 'bin-Test_case_2-1.log'),
@@ -342,6 +342,7 @@ class TestTask(unittest.TestCase):
                                    os.path.join(root(), 'c', 'd', 'bin'),
                                    'Test.case', 1))
 
+  def test_logs_to_temporary_files_without_output_dir(self):
     log_file = gtest_parallel.Task._logname(None, None, None, None)
     self.assertEqual(tempfile.gettempdir(), os.path.dirname(log_file))
     os.remove(log_file)

--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
-import gtest_parallel
 import os.path
 import random
 import shutil
@@ -21,6 +20,8 @@ import sys
 import tempfile
 import threading
 import unittest
+
+import gtest_parallel
 
 from gtest_parallel_mocks import LoggerMock
 from gtest_parallel_mocks import SubprocessMock
@@ -287,6 +288,14 @@ class TestTestTimes(unittest.TestCase):
 
           times.write_to_file(save_file)
 
+        self.assertEqual(
+          1000,
+          times.get_test_time('{}-{}'.format(path_to_binary, cnt),
+                              'TestFoo.testBar'))
+        self.assertIsNone(
+          times.get_test_time('{}-{}'.format(path_to_binary, cnt),
+                              'baz'))
+
       t = threading.Thread(target=test_times_worker)
       t.start()
       return t
@@ -300,7 +309,7 @@ class TestTestTimes(unittest.TestCase):
           worker.join()
 
 
-class TestFilterFormat(unittest.TestCase):
+class TestTask(unittest.TestCase):
   def test_log_file_names(self):
     def root():
       return 'C:\\' if sys.platform == 'win32' else '/'
@@ -332,6 +341,133 @@ class TestFilterFormat(unittest.TestCase):
       gtest_parallel.Task._logname(os.path.join(root(), 'a', 'b'),
                                    os.path.join(root(), 'c', 'd', 'bin'),
                                    'Test.case', 1))
+
+    log_file = gtest_parallel.Task._logname(None, None, None, None)
+    self.assertEqual(tempfile.gettempdir(), os.path.dirname(log_file))
+    os.remove(log_file)
+
+  def _execute_run_test(self, run_test_body, interrupt_test):
+    def popen_mock(*_args, **_kwargs):
+      return None
+
+    class SigHandlerMock(object):
+      class ProcessWasInterrupted(Exception):
+        pass
+
+      def wait(*_args):
+        if interrupt_test:
+          raise SigHandlerMock.ProcessWasInterrupted()
+
+        return 42
+
+    with guard_temp_dir() as temp_dir, \
+        guard_patch_module('subprocess.Popen', popen_mock), \
+        guard_patch_module('sigint_handler', SigHandlerMock()), \
+        guard_patch_module('thread.exit', lambda: None):
+      run_test_body(temp_dir)
+
+  def test_run_normal_task(self):
+    def run_test(temp_dir):
+      task = gtest_parallel.Task('fake/binary', 'test', ['fake/binary'],
+                                 1, None, temp_dir)
+
+      self.assertFalse(os.path.isfile(task.log_file))
+
+      task.run()
+
+      self.assertTrue(os.path.isfile(task.log_file))
+      self.assertEqual(42, task.exit_code)
+
+    self._execute_run_test(run_test, False)
+
+  def test_run_interrupted_task_with_transient_log(self):
+    def run_test(_):
+      task = gtest_parallel.Task('fake/binary', 'test', ['fake/binary'],
+                                 1, None, None)
+
+      self.assertTrue(os.path.isfile(task.log_file))
+
+      task.run()
+
+      self.assertTrue(os.path.isfile(task.log_file))
+      self.assertIsNone(task.exit_code)
+
+    self._execute_run_test(run_test, True)
+
+
+class TestFilterFormat(unittest.TestCase):
+  def _execute_test(self, test_body, drop_output):
+    class StdoutMock(object):
+      def isatty(*_args):
+        return False
+
+      def write(*args):
+        pass
+
+    with guard_temp_dir() as temp_dir, \
+        guard_patch_module('sys.stdout', StdoutMock()):
+      logger = gtest_parallel.FilterFormat(None if drop_output else temp_dir)
+      logger.log_tasks(42)
+
+      test_body(logger)
+
+      logger.flush()
+
+  def test_no_output_dir(self):
+    def run_test(logger):
+      passed = [
+          TaskMock(
+            ('fake/binary', 'FakeTest'), 0, {
+              'runtime_ms': [10],
+              'exit_code': [0],
+              'last_execution_time': [10],
+              'log_file': [os.path.join(tempfile.gettempdir(), 'fake.log')]
+          })
+      ]
+
+      open(passed[0].log_file, 'w').close()
+      self.assertTrue(os.path.isfile(passed[0].log_file))
+
+      logger.log_exit(passed[0])
+
+      self.assertFalse(os.path.isfile(passed[0].log_file))
+
+      logger.print_tests('', passed, True)
+      logger.move_to(None, passed)
+
+      logger.summarize(passed, [], [])
+
+    self._execute_test(run_test, True)
+
+  def test_with_output_dir(self):
+    def run_test(logger):
+      failed = [
+          TaskMock(
+            ('fake/binary', 'FakeTest'), 0, {
+              'runtime_ms': [10],
+              'exit_code': [1],
+              'last_execution_time': [10],
+              'log_file': [os.path.join(logger.output_dir, 'fake.log')]
+          })
+      ]
+
+      open(failed[0].log_file, 'w').close()
+      self.assertTrue(os.path.isfile(failed[0].log_file))
+
+      logger.log_exit(failed[0])
+
+      self.assertTrue(os.path.isfile(failed[0].log_file))
+
+      logger.print_tests('', failed, True)
+      logger.move_to('failed', failed)
+
+      self.assertFalse(os.path.isfile(failed[0].log_file))
+      self.assertTrue(
+        os.path.isfile(os.path.join(logger.output_dir, 'failed', 'fake.log')))
+
+      logger.summarize([], failed, [])
+
+    self._execute_test(run_test, False)
 
 
 class TestFindTests(unittest.TestCase):
@@ -389,6 +525,11 @@ class TestFindTests(unittest.TestCase):
     with guard_patch_module('subprocess.check_output', subprocess_mock):
       tasks = gtest_parallel.find_tests(
         test_data.keys(), [], options, TestTimesMock(self, test_data))
+    # Clean transient tasks' log files created because
+    # by default now output_dir is None.
+    for task in tasks:
+      if os.path.isfile(task.log_file):
+        os.remove(task.log_file)
     return tasks, subprocess_mock
 
   def test_tasks_are_sorted(self):
@@ -437,6 +578,7 @@ class TestFindTests(unittest.TestCase):
         arg.startswith('--gtest_filter=SomeFilter')
         for arg in subprocess_mock.last_invocation
     ))
+
   def test_applies_gtest_filter(self):
     _, subprocess_mock = self._call_find_tests(
         self.ONE_TEST, ['--gtest_filter=SomeFilter'])


### PR DESCRIPTION
If --output_dir command line options is omitted then
gtest-parallel does not save any log files at all.
Temporary files used for logging in this case are
removed immediately after test's exit. Logs for
failing tests are still dumped to console.