### PR TITLE
XML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,15 @@ to avoid mixing old stale logs with new ones. This will discard any logs from
 ongoing invocations, or otherwise fail (throw) because the files are in use
 (depending on platform). This is not enforced by a lock file as cleaning these
 up would require unnecessary user intervention.
+
+## XML Output
+
+This script is able to save test results in XML format. Use
+`--dump_xml_test_results=` to enable XML output and specify file name.
+By default standard error and output are saved in XML for failed tests.
+Include `--dump_xml_all_logs` in command line to save output of all logs.
+
+For example:
+
+    $ ./gtest-parallel path/to/binary... --dump_xml_test_results=example.xml --dump_xml_all_logs
+

--- a/README.md
+++ b/README.md
@@ -91,12 +91,16 @@ this permits such binaries to partially benefit from parallel execution.
 
 ## XML Output
 
-This script is able to save test results in XML format. Use
-`--dump_xml_test_results=` to enable XML output and specify file name.
-By default standard error and output are saved in XML for failed tests.
-Include `--dump_xml_all_logs` in command line to save output of all logs.
+This script supports saving test results as Google Test XML. Use
+`--gtest_output=FORMAT[:DIRECTORY_PATH/|:FILE_PATH]` parameter to enable
+this feature. FORMAT is either `xml` or `xml-full`. FILE_PATH defaults to
+test_detail.xml.
+
+Standard error and output are saved in `<system-out>` tag under `<testcase> tag
+in addition to other Google Test XML data. In `xml` format only failed tests
+have output saved. In `xml-full` format output is saved for all tests.
 
 For example:
 
-    $ ./gtest-parallel path/to/binary... --dump_xml_test_results=example.xml --dump_xml_all_logs
+    $ ./gtest-parallel path/to/binary... --gtest_output=xml:example.xml
 

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -446,7 +446,7 @@ class CollectXMLTestResults(object):
 
   def log(self, task):
     failed = task.exit_code != 0
-    xml_text = self._read_file('{}.{}'.format(task.log_file, self.xml_format))
+    xml_text = self._read_file(task.log_file + '.xml')
     # Remember standard output if failed or asked to always include it in XML
     log_text = None
     if failed or self.xml_format == 'xml-full':

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -497,8 +497,10 @@ class CollectXMLTestResults(object):
       xgroup = ET.SubElement(xroot, 'testsuite', self._to_str(group['attrib']))
       for test in group['children'].values():
         xtest = ET.SubElement(xgroup, 'testcase', self._to_str(test['attrib']))
+        if test['failed']:
+          ET.SubElement(xtest, 'failure', {'message': 'exit status is not 0',})
         if test['output']:
-          ET.SubElement(xgroup, 'system-out').text = test['output']
+          ET.SubElement(xtest, 'system-out').text = test['output']
     ET.ElementTree(xroot).write(self.xml_dump_filepath, encoding = 'UTF-8')
 
 


### PR DESCRIPTION
I often use google test library together with Jenkins and I like running them in parallel. I find gtest-parallel script very useful but somehow it doesn't have XML output compatible with Jenkins JUnit plugin. To get things working out of the box I refactored script to allow different test results collectors and added XML results collector.
Similar to `--dump_json_test_results=DUMP_JSON_TEST_RESULTS` there is `--dump_xml_test_results=DUMP_XML_TEST_RESULTS` added.
Additional option `--dump_xml_all_logs` controls if output logs of all tests are saved in XML, I often need this included and this is even better than gtest XML output because gtest-parallel captures whole and all output (in my case gtest may run under simulator which may report additional info).
