### PR TITLE
Print output from binary if --gtest_list fails.

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -579,7 +579,7 @@ def find_tests(binaries, additional_args, options, times):
       test_list = subprocess.check_output(list_command,
                                           stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-      sys.exit("%s: %s" % (test_binary, str(e)))
+      sys.exit("%s: %s\n%s" % (test_binary, str(e), e.output))
 
     try:
         test_list = test_list.split('\n')


### PR DESCRIPTION
I had a binary run by gtest_parallel that failed like this:

/modules_tests: error while loading shared libraries: libpipewire-0.2.so.1: cannot open shared object file: No such file or directory

However, the first --gtest_list invocation ate that output which made it a lot harder to debug. This change will make gtest_parallel print stdout and stderr of the binary in case the invocation fails.