### PR TITLE
Use /usr/bin/env python

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Now that gtest-parallel should work with both Python 2 and Python 3 we
don't need to call out to a specific version. Also python2 doesn't exist
on all systems.