### PR TITLE
Adding year and name of copyright owner in LICENSE file. (#68)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+   

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2013] [Google Inc.]
+   Copyright 2013 Google Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2013] [Google Inc.]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Apache License V2.0 requires the LICENSE to have
the year and name of the copyright owner. The values
are present in LICENSE file and have to be edited
when applied to the projects. I think it was missed
for this project. So adding it and sending a patch.
Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>