### PR TITLE
Let an OS decide which Python version to use to run tests

### DIFF
--- a/gtest_parallel_tests.py
+++ b/gtest_parallel_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Scripts are python 3 ready, therefore it's better not to hard code python 2 which may not even be available on some systems.