### PR TITLE
Add an option to print task status continuously

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -300,7 +300,7 @@ class TaskManager(object):
 
 
 class FilterFormat(object):
-  def __init__(self, output_dir):
+  def __init__(self, output_dir, print_task_status_continuously=False):
     if sys.stdout.isatty():
       # stdout needs to be unbuffered since the output is interactive.
       if isinstance(sys.stdout, io.TextIOWrapper):
@@ -316,6 +316,7 @@ class FilterFormat(object):
 
     self.total_tasks = 0
     self.finished_tasks = 0
+    self.print_task_status_continuously = print_task_status_continuously
     self.out = Outputter(sys.stdout)
     self.stdout_lock = threading.Lock()
 
@@ -342,9 +343,12 @@ class FilterFormat(object):
   def log_exit(self, task):
     with self.stdout_lock:
       self.finished_tasks += 1
-      self.out.transient_line("[%d/%d] %s (%d ms)"
-                              % (self.finished_tasks, self.total_tasks,
-                                 task.test_name, task.runtime_ms))
+      msg = "[%d/%d] %s (%d ms)" % (self.finished_tasks, self.total_tasks,
+                                    task.test_name, task.runtime_ms)
+      if self.print_task_status_continuously:
+        self.out.permanent_line(msg)
+      else:
+        self.out.transient_line(msg)
       if task.exit_code != 0:
         with open(task.log_file) as f:
           for line in f.readlines():
@@ -722,6 +726,10 @@ def default_options_parser():
   parser.add_option('--serialize_test_cases', action='store_true',
                     default=False, help='Do not run tests from the same test '
                                         'case in parallel.')
+  parser.add_option('--print_task_status_continuously', action='store_true',
+                    default=False, help='Print task status continuously on a'
+                                        'separate line, instead of over'
+                                        'writing the current line.')
   return parser
 
 
@@ -793,7 +801,8 @@ def main():
   save_file = get_save_file_path()
 
   times = TestTimes(save_file)
-  logger = FilterFormat(options.output_dir)
+  logger = FilterFormat(options.output_dir,
+                        options.print_task_status_continuously)
 
   task_manager = TaskManager(times, logger, test_results, Task,
                              options.retry_failed, options.repeat + 1)

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -120,6 +120,7 @@ class Outputter(object):
   def transient_line(self, msg):
     if self.__width is None:
       self.__out_file.write(msg + "\n")
+      self.__out_file.flush()
     else:
       self.__out_file.write("\r" + msg[:self.__width].ljust(self.__width))
       self.__previous_line_was_transient = True
@@ -130,6 +131,8 @@ class Outputter(object):
   def permanent_line(self, msg):
     self.flush_transient_output()
     self.__out_file.write(msg + "\n")
+    if self.__width is None:
+      self.__out_file.flush()
 
 
 def get_save_file_path():


### PR DESCRIPTION
Seems in non-tty mode the write is buffered. If the output data is small, it won't print out until all tests are done.