### PR TITLE
Handle Google PRE_ tests

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -615,7 +615,6 @@ def find_tests(binaries, additional_args, options, times):
       if '.PRE_' in test_name :
         continue
 
-
       last_execution_time = times.get_test_time(test_binary, test_name)
       if options.failed and last_execution_time is not None:
         continue

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -611,6 +611,11 @@ def find_tests(binaries, additional_args, options, times):
       if not options.gtest_also_run_disabled_tests and 'DISABLED_' in test_name:
         continue
 
+      # Skip PRE_ tests which are used by Chromium.
+      if '.PRE_' in test_name :
+        continue
+
+
       last_execution_time = times.get_test_time(test_binary, test_name)
       if options.failed and last_execution_time is not None:
         continue


### PR DESCRIPTION
PRE_ tests are executed by the test executable; gtest_parallel should ignore them.