### PR TITLE
add support for {#} similar to parallel

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -662,7 +662,8 @@ def find_tests(binaries, additional_args, options, times):
       if options.failed and last_execution_time is not None:
         continue
 
-      test_command = command + ['--gtest_filter=' + test_name]
+      test_command = [a.replace('{#}', f"{test_count}")
+                      for a in command] + ['--gtest_filter=' + test_name]
       if (test_count - options.shard_index) % options.shard_count == 0:
         for execution_number in range(options.repeat):
           tasks.append(


### PR DESCRIPTION
allows for `--gtest_output=xml:reports/report_{#}.xml` to be used instead
of relying on googletest itself to lock a unique filename and using that

usage would be something like

```bash
python \
    gtest_parallel.py \
    --print_test_times \
    ./unit_tests \
    -- \
    --gtest_output="xml:reports/{#}.xml"
```

and then uploading the `reports/*.xml` files for junit reports or using something like junitparser to merge them together.

Formatted using yapf, so that's where the extra spaces come from.