### PR TITLE
Make gtest-parallel to use python3

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
According to the Google Python style guide [1] and the Chromium Python
style guide [2], the shebang should be #!/usr/bin/env python3.
This is useful for running WebRTC unittests in python2-less environment.

[1] https://google.github.io/styleguide/pyguide.html
[2] https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/python/python.md